### PR TITLE
Fix desktop ZIP save dialog flow

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -9114,22 +9114,51 @@
       });
     }
 
-    async function saveBlob(blob, fileName, mimeType = 'application/octet-stream') {
+    function normalizeExportBlob(blob, mimeType = 'application/octet-stream') {
       if (!(blob instanceof Blob)) {
         throw new Error('Export payload is not a Blob.');
       }
+      return blob.type ? blob : new Blob([blob], { type: mimeType });
+    }
 
-      const normalizedBlob = blob.type ? blob : new Blob([blob], { type: mimeType });
+    function normalizeSaveResult(result) {
+      return {
+        saved: Boolean(result && result.saved),
+        path: result && result.path ? result.path : null
+      };
+    }
+
+    async function pickDesktopSavePath(fileName) {
+      if (!isTauriDesktop()) return null;
+      const path = await window.__TAURI__.core.invoke('pick_export_file_path', {
+        suggestedName: fileName
+      });
+      return typeof path === 'string' && path ? path : null;
+    }
+
+    async function writeBlobToDesktopPath(blob, targetPath, mimeType = 'application/octet-stream') {
+      if (!isTauriDesktop()) {
+        throw new Error('Desktop path writes require the Tauri runtime.');
+      }
+
+      const normalizedBlob = normalizeExportBlob(blob, mimeType);
+      const bytesBase64 = await blobToBase64(normalizedBlob);
+      const result = await window.__TAURI__.core.invoke('write_export_file_to_path', {
+        path: targetPath,
+        bytesBase64
+      });
+      return normalizeSaveResult(result);
+    }
+
+    async function saveBlob(blob, fileName, mimeType = 'application/octet-stream') {
+      const normalizedBlob = normalizeExportBlob(blob, mimeType);
       if (isTauriDesktop()) {
         const bytesBase64 = await blobToBase64(normalizedBlob);
         const result = await window.__TAURI__.core.invoke('save_export_file', {
           suggestedName: fileName,
           bytesBase64
         });
-        return {
-          saved: Boolean(result && result.saved),
-          path: result && result.path ? result.path : null
-        };
+        return normalizeSaveResult(result);
       }
 
       downloadBlobInBrowser(normalizedBlob, fileName);
@@ -9985,6 +10014,22 @@
       if (typeof JSZipCtor !== 'function') {
         throw new Error('JSZip module is unavailable');
       }
+
+      const zipFileName = 'converted_negatives.zip';
+      let desktopZipTargetPath = null;
+      if (isTauriDesktop()) {
+        // Pick the destination before the long-running batch starts so macOS can
+        // surface the save panel immediately instead of after processing finishes.
+        desktopZipTargetPath = await pickDesktopSavePath(zipFileName);
+        if (!desktopZipTargetPath) {
+          handleSaveResult({ saved: false, path: null }, {
+            cancelledKey: 'zipSaveCancelled',
+            cancelledFallback: 'ZIP save cancelled. No file was written.'
+          });
+          return;
+        }
+      }
+
       const zip = new JSZipCtor();
       const exportInfo = getExportInfo();
       let processedCount = 0;
@@ -10028,7 +10073,9 @@
           compressionOptions: { level: 6 }
         });
 
-        const result = await saveBlob(zipBlob, 'converted_negatives.zip', 'application/zip');
+        const result = desktopZipTargetPath
+          ? await writeBlobToDesktopPath(zipBlob, desktopZipTargetPath, 'application/zip')
+          : await saveBlob(zipBlob, zipFileName, 'application/zip');
         handleSaveResult(result, {
           cancelledKey: 'zipSaveCancelled',
           cancelledFallback: 'ZIP save cancelled. No file was written.',

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,8 +2,9 @@ use base64::Engine;
 use serde::Serialize;
 #[cfg(target_os = "linux")]
 use std::io::ErrorKind;
+use std::path::PathBuf;
 #[cfg(target_os = "linux")]
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Serialize)]
@@ -15,6 +16,46 @@ struct SaveResult {
 #[tauri::command]
 fn get_app_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
+}
+
+fn normalize_export_path(mut path: PathBuf, suggested_name: &str) -> PathBuf {
+    let suggested_extension = std::path::Path::new(suggested_name)
+        .extension()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty());
+
+    if path.extension().is_none() {
+        if let Some(extension) = suggested_extension {
+            path.set_extension(extension);
+        }
+    }
+
+    path
+}
+
+fn decode_export_bytes(bytes_base64: &str) -> Result<Vec<u8>, String> {
+    base64::engine::general_purpose::STANDARD
+        .decode(bytes_base64)
+        .map_err(|err| format!("decode base64 failed: {err}"))
+}
+
+fn write_export_bytes(path: &PathBuf, bytes_base64: &str) -> Result<SaveResult, String> {
+    let bytes = decode_export_bytes(bytes_base64)?;
+    std::fs::write(path, bytes).map_err(|err| format!("write file failed: {err}"))?;
+
+    Ok(SaveResult {
+        saved: true,
+        path: Some(path.to_string_lossy().to_string()),
+    })
+}
+
+#[tauri::command]
+fn pick_export_file_path(suggested_name: String) -> Option<String> {
+    let path = rfd::FileDialog::new()
+        .set_file_name(&suggested_name)
+        .save_file()?;
+    let normalized = normalize_export_path(path, &suggested_name);
+    Some(normalized.to_string_lossy().to_string())
 }
 
 #[tauri::command]
@@ -29,16 +70,18 @@ fn save_export_file(suggested_name: String, bytes_base64: String) -> Result<Save
         });
     };
 
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(bytes_base64)
-        .map_err(|err| format!("decode base64 failed: {err}"))?;
+    let normalized = normalize_export_path(path, &suggested_name);
+    write_export_bytes(&normalized, &bytes_base64)
+}
 
-    std::fs::write(&path, bytes).map_err(|err| format!("write file failed: {err}"))?;
+#[tauri::command]
+fn write_export_file_to_path(path: String, bytes_base64: String) -> Result<SaveResult, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("export path is empty".to_string());
+    }
 
-    Ok(SaveResult {
-        saved: true,
-        path: Some(path.to_string_lossy().to_string()),
-    })
+    write_export_bytes(&PathBuf::from(trimmed), &bytes_base64)
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -441,6 +484,8 @@ pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             save_export_file,
+            pick_export_file_path,
+            write_export_file_to_path,
             get_app_version,
             open_external_url
         ])
@@ -451,9 +496,11 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{
-        decide_dmabuf_policy, looks_like_legacy_appimage_name, parse_bool_flag, AppImageVariant,
-        DmabufDecision, DmabufDisableReason, DmabufKeepReason, DmabufProbeKind,
+        decide_dmabuf_policy, looks_like_legacy_appimage_name, normalize_export_path,
+        parse_bool_flag, AppImageVariant, DmabufDecision, DmabufDisableReason,
+        DmabufKeepReason, DmabufProbeKind,
     };
+    use std::path::PathBuf;
 
     #[test]
     fn parse_bool_flag_accepts_truthy_values() {
@@ -487,6 +534,19 @@ mod tests {
             "Negative Converter_0.1.4_amd64.AppImage"
         ));
         assert!(!looks_like_legacy_appimage_name("legacy-build.AppImage"));
+    }
+
+    #[test]
+    fn normalize_export_path_adds_missing_extension_from_suggested_name() {
+        let path = normalize_export_path(PathBuf::from("/tmp/converted_negatives"), "converted.zip");
+        assert_eq!(path, PathBuf::from("/tmp/converted_negatives.zip"));
+    }
+
+    #[test]
+    fn normalize_export_path_preserves_explicit_extension() {
+        let path =
+            normalize_export_path(PathBuf::from("/tmp/converted_negatives.custom"), "converted.zip");
+        assert_eq!(path, PathBuf::from("/tmp/converted_negatives.custom"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- pick the ZIP destination before batch processing starts on desktop
- add Tauri commands to select an export path and write ZIP bytes to that exact path
- keep single-file export behavior unchanged while preserving ZIP save/cancel feedback

## Verification
- npm run build:web
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml