### PR TITLE
Add support for more LibRaw-supported RAW formats

### DIFF
--- a/negative2positive/index.html
+++ b/negative2positive/index.html
@@ -2634,8 +2634,8 @@
           <p data-i18n="dropHint">Drop image here or click to open</p>
           <label class="upload-btn" id="uploadBtn" for="fileInput" role="button" tabindex="0" data-i18n="selectFile">Select File</label>
           <label class="upload-btn secondary" id="uploadFolderBtn" for="folderInput" role="button" tabindex="0" data-i18n="selectFolder">Select Folder</label>
-          <input type="file" id="fileInput" class="hidden-file-input" accept=".cr2,.crw,.nef,.arw,.dng,.raf,.raw,.rw2,.pef,.srw,.3fr,.orf,.tif,.tiff,image/*" multiple>
-          <input type="file" id="folderInput" class="hidden-file-input" accept=".cr2,.crw,.nef,.arw,.dng,.raf,.raw,.rw2,.pef,.srw,.3fr,.orf,.tif,.tiff,image/*" webkitdirectory directory multiple>
+          <input type="file" id="fileInput" class="hidden-file-input" accept=".cr2,.cr3,.crw,.nef,.nrw,.arw,.dng,.raf,.raw,.rw2,.pef,.srw,.3fr,.mef,.orf,.rwl,.iiq,.x3f,.mrw,.kdc,.dcr,.tif,.tiff,image/*" multiple>
+          <input type="file" id="folderInput" class="hidden-file-input" accept=".cr2,.cr3,.crw,.nef,.nrw,.arw,.dng,.raf,.raw,.rw2,.pef,.srw,.3fr,.mef,.orf,.rwl,.iiq,.x3f,.mrw,.kdc,.dcr,.tif,.tiff,image/*" webkitdirectory directory multiple>
           <div class="upload-support-hint" id="folderPickerHint" data-i18n="folderPickerUnsupported">Folder selection is not supported in this browser. Please use Select File.</div>
         </div>
         <div class="canvas-transform-wrapper" id="canvasTransformWrapper">

--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -6092,7 +6092,7 @@
       const placeholder = document.getElementById('uploadPlaceholder');
       placeholder.innerHTML = `<p>${i18n[currentLang].processing}</p>`;
       const fileName = file.name.toLowerCase();
-      const isRawLikeFile = ['.cr2', '.crw', '.nef', '.arw', '.dng', '.raf', '.raw', '.rw2', '.pef', '.srw', '.3fr', '.orf', '.tif', '.tiff'].some(ext => fileName.endsWith(ext));
+      const isRawLikeFile = ['.cr2', '.cr3', '.crw', '.nef', '.nrw', '.arw', '.dng', '.raf', '.raw', '.rw2', '.pef', '.srw', '.3fr', '.mef', '.orf', '.rwl', '.iiq', '.x3f', '.mrw', '.kdc', '.dcr', '.tif', '.tiff'].some(ext => fileName.endsWith(ext));
       closeFrontierGuidePopup();
 
       const overlay = getLoadingOverlay();
@@ -10295,7 +10295,7 @@
       const arrayBuffer = await file.arrayBuffer();
       const fileName = file.name.toLowerCase();
 
-      if (['.cr2', '.crw', '.nef', '.arw', '.dng', '.raf', '.raw', '.rw2', '.pef', '.srw', '.3fr', '.orf', '.tif', '.tiff'].some(ext => fileName.endsWith(ext))) {
+      if (['.cr2', '.cr3', '.crw', '.nef', '.nrw', '.arw', '.dng', '.raf', '.raw', '.rw2', '.pef', '.srw', '.3fr', '.mef', '.orf', '.rwl', '.iiq', '.x3f', '.mrw', '.kdc', '.dcr', '.tif', '.tiff'].some(ext => fileName.endsWith(ext))) {
         return await loadRawFile(arrayBuffer, fileName);
       } else if (file.type === 'image/png') {
         return loadPngFile(arrayBuffer);
@@ -11219,7 +11219,7 @@
       const input = document.createElement('input');
       input.type = 'file';
       input.multiple = true;
-      input.accept = '.cr2,.crw,.nef,.arw,.dng,.raf,.raw,.rw2,.pef,.srw,.3fr,.orf,.tif,.tiff,image/*';
+      input.accept = '.cr2,.cr3,.crw,.nef,.nrw,.arw,.dng,.raf,.raw,.rw2,.pef,.srw,.3fr,.mef,.orf,.rwl,.iiq,.x3f,.mrw,.kdc,.dcr,.tif,.tiff,image/*';
       input.onchange = (e) => {
         if (isDesktopBatchExportLocked()) return;
         if (e.target.files.length > 0) {
@@ -11260,7 +11260,7 @@
 
     function addFilesToQueue(files) {
       // Filter for supported image files
-      const supportedExtensions = ['.cr2', '.crw', '.nef', '.arw', '.dng', '.raf', '.raw', '.rw2', '.pef', '.srw', '.3fr', '.orf', '.tif', '.tiff', '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'];
+      const supportedExtensions = ['.cr2', '.cr3', '.crw', '.nef', '.nrw', '.arw', '.dng', '.raf', '.raw', '.rw2', '.pef', '.srw', '.3fr', '.mef', '.orf', '.rwl', '.iiq', '.x3f', '.mrw', '.kdc', '.dcr', '.tif', '.tiff', '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'];
       const validFiles = files.filter(file => {
         const ext = '.' + file.name.split('.').pop().toLowerCase();
         return supportedExtensions.includes(ext) || file.type.startsWith('image/');


### PR DESCRIPTION
## Summary
Round out the RAW-format whitelist after PR #79. Most notable addition is `.cr3` — Canon's current-generation format used across the entire R-series and recent EOS bodies, far more widespread today than `.crw`.

| Ext | Vendor / Notes |
|---|---|
| `.cr3` | Canon R-series, recent EOS |
| `.nrw` | Nikon Coolpix (NEF variant) |
| `.rwl` | Leica |
| `.iiq` | Phase One |
| `.x3f` | Sigma Foveon |
| `.mrw` | Minolta (legacy, pre-Sony) |
| `.kdc` | Kodak (older) |
| `.dcr` | Kodak (newer) |
| `.mef` | Mamiya |

Same 5-spot whitelist edit as PR #79 — no engine / decoder / state changes. LibRaw handles all of these natively.

## Test plan
- [x] `npm run build:web` clean
- [ ] Drag a Canon `.cr3` (R5/R6/etc.) → routes to RAW path, decodes successfully
- [ ] Other RAW formats added in PR #79 still working — regression
- [ ] File picker shows the new formats as selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)