### PR TITLE
Fix NEF preview fallback selecting no IFD on real Nikon Z f files

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -6270,7 +6270,7 @@
       const isIIQ = fileName.endsWith('.iiq');
       if (isIIQ && bufBytes > RAW_SIZE_HEAVY) {
         console.info('[RAW] heavy IIQ detected, taking embedded preview shortcut');
-        const previewImageData = tryNefJpegPreview(buffer);
+        const previewImageData = await tryNefJpegPreview(buffer);
         if (previewImageData) {
           console.warn('[RAW] embedded preview decoded — precision is downgraded to 8-bit for this file.');
           previewImageData.__image16 = fromImageData8(previewImageData);
@@ -6299,9 +6299,9 @@
         try { raw.worker?.terminate?.(); } catch {}
       };
 
-      const handleTimeoutFallback = () => {
+      const handleTimeoutFallback = async () => {
         killWorker();
-        const previewImageData = tryNefJpegPreview(buffer);
+        const previewImageData = await tryNefJpegPreview(buffer);
         if (previewImageData) {
           console.warn('[RAW] LibRaw timed out — using embedded preview (8-bit precision).');
           previewImageData.__image16 = fromImageData8(previewImageData);
@@ -6329,7 +6329,7 @@
       } catch (err) {
         if (err?.code === 'RAW_DECODE_TIMEOUT') {
           console.warn('[RAW] raw.open timed out');
-          return handleTimeoutFallback();
+          return await handleTimeoutFallback();
         }
         throw err;
       }
@@ -6362,7 +6362,7 @@
       } catch (err) {
         if (err?.code === 'RAW_DECODE_TIMEOUT') {
           console.warn('[RAW] raw.imageData timed out');
-          return handleTimeoutFallback();
+          return await handleTimeoutFallback();
         }
         throw err;
       }
@@ -6393,7 +6393,7 @@
       // NEF carries — same approach as the iPhone ProRaw handler above.
       if (looksLikeBayerSnow(image16)) {
         console.warn('[RAW] decoded output looks un-demosaiced; trying embedded JPEG preview fallback');
-        const previewImageData = tryNefJpegPreview(buffer);
+        const previewImageData = await tryNefJpegPreview(buffer);
         if (previewImageData) {
           console.warn('[RAW] embedded preview decoded — precision is downgraded to 8-bit for this file.');
           previewImageData.__image16 = fromImageData8(previewImageData);

--- a/negative2positive/src/app/nefJpegPreview.js
+++ b/negative2positive/src/app/nefJpegPreview.js
@@ -1,10 +1,15 @@
 // Fallback decoder for Nikon NEF (and other TIFF-based RAWs) when LibRaw can't
 // decode the proprietary Bayer stream — most commonly Z9/Z8/Zf in
 // "high-efficiency (HE/HE*)" compression mode. Every NEF carries a
-// camera-rendered, full-resolution JPEG preview inside a SubIFD; we walk the
-// TIFF container, find the largest JPEG-compressed image, and let UTIF decode
-// it. Same three-step pattern as the iPhone ProRaw fallback already in
-// `loadRawFile`, only the IFD selection is different.
+// camera-rendered JPEG preview inside a SubIFD; we walk the TIFF container,
+// find the largest JPEG-compressed image, and decode it with the browser's
+// native JPEG decoder via `createImageBitmap`.
+//
+// We deliberately do NOT use `UTIF.decodeImage` for the preview step:
+// camera-embedded preview IFDs typically only carry t513/t514 (JPEG offset +
+// length) and omit t256/t257/t258 plus the strip-based (t273/t279) fields
+// that UTIF expects. UTIF silently no-ops in that shape. Slicing the bytes
+// out and handing them to the browser's JPEG decoder is more reliable.
 
 import UTIFImport from 'utif';
 
@@ -27,6 +32,69 @@ const COMPRESSION_NEW_JPEG = 7;
 // let the caller throw a friendly error instead.
 const MIN_PREVIEW_WIDTH = 1000;
 
+/**
+ * Read width/height from a JPEG byte stream's SOF (Start Of Frame) marker.
+ * Many camera-embedded preview JPEGs in NEFs don't carry t256/t257 in their
+ * IFD — the only place to get true dimensions is parsing the JPEG itself.
+ *
+ * @param {ArrayBuffer} buffer  full container buffer
+ * @param {number} offset       byte offset of the JPEG within the container
+ * @param {number} length       byte length of the JPEG
+ * @returns {{w: number, h: number} | null}
+ */
+export function readJpegDimensionsFromSOF(buffer, offset, length) {
+  if (!buffer || typeof offset !== 'number' || typeof length !== 'number') return null;
+  if (offset < 0 || length <= 4) return null;
+  const end = Math.min(offset + length, buffer.byteLength);
+  if (end - offset < 4) return null;
+  const bytes = new Uint8Array(buffer, offset, end - offset);
+
+  // Verify SOI (Start Of Image)
+  if (bytes[0] !== 0xFF || bytes[1] !== 0xD8) return null;
+
+  let p = 2;
+  // Each segment is `FF Mn LL LL [payload]`, except standalone markers
+  // (SOI/EOI/RSTn/TEM) which are just `FF Mn`. SOF markers carry dimensions
+  // at a fixed offset within the payload.
+  while (p + 1 < bytes.length) {
+    if (bytes[p] !== 0xFF) return null;
+    // Skip marker padding bytes (0xFF fill before the actual marker code)
+    let q = p + 1;
+    while (q < bytes.length && bytes[q] === 0xFF) q++;
+    if (q >= bytes.length) return null;
+    const marker = bytes[q];
+    p = q;
+
+    // Standalone markers — no segment length, just the 2 bytes
+    if (marker === 0xD8 || marker === 0xD9 || (marker >= 0xD0 && marker <= 0xD7) || marker === 0x01) {
+      p += 1;  // already at marker byte; advance past it
+      continue;
+    }
+
+    // Start Of Frame markers (carry width/height).
+    // Range C0–CF, but C4 (DHT), C8 (JPG reserved), CC (DAC) are NOT frames.
+    if (marker >= 0xC0 && marker <= 0xCF && marker !== 0xC4 && marker !== 0xC8 && marker !== 0xCC) {
+      // Layout from marker byte: marker(1) + segLen(2) + precision(1) + height(2) + width(2)
+      if (p + 7 >= bytes.length) return null;
+      const height = (bytes[p + 4] << 8) | bytes[p + 5];
+      const width = (bytes[p + 6] << 8) | bytes[p + 7];
+      if (width <= 0 || height <= 0) return null;
+      return { w: width, h: height };
+    }
+
+    // SOS = Start Of Scan = compressed image data begins.
+    // If we hit it before any SOF, the JPEG is malformed for our purposes.
+    if (marker === 0xDA) return null;
+
+    // Otherwise: variable-length segment, skip it
+    if (p + 3 >= bytes.length) return null;
+    const segLen = (bytes[p + 1] << 8) | bytes[p + 2];
+    if (segLen < 2) return null;
+    p = p + 1 + segLen;  // marker byte + segment payload
+  }
+  return null;
+}
+
 function collectAllIfds(topIfds) {
   const out = [];
   const visited = new WeakSet();
@@ -48,35 +116,62 @@ function getIfdDim(ifd, key) {
   return Array.isArray(v) && v.length > 0 ? Number(v[0]) || 0 : 0;
 }
 
-function pickLargestJpegIfd(ifds) {
+function getIfdJpegPointer(ifd) {
+  const offset = ifd[TIFF_TAG_JPEG_OFFSET]?.[0];
+  const length = ifd[TIFF_TAG_JPEG_LENGTH]?.[0];
+  if (typeof offset !== 'number' || typeof length !== 'number') return null;
+  return { offset, length };
+}
+
+function getIfdJpegDimensions(ifd, arrayBuffer) {
+  // 1) Prefer the IFD's own t256/t257 when present (cheap, exact)
+  const tw = getIfdDim(ifd, TIFF_TAG_IMAGE_WIDTH);
+  const th = getIfdDim(ifd, TIFF_TAG_IMAGE_LENGTH);
+  if (tw > 0 && th > 0) return { w: tw, h: th };
+
+  // 2) Fall back to parsing the JPEG byte stream's SOF marker. Most NEF
+  //    camera-rendered preview IFDs (top0 / first subIFD) leave t256/t257
+  //    blank and only encode dimensions inside the JPEG itself.
+  const ptr = getIfdJpegPointer(ifd);
+  if (!ptr) return null;
+  return readJpegDimensionsFromSOF(arrayBuffer, ptr.offset, ptr.length);
+}
+
+function isJpegIfd(ifd) {
+  const cmpr = ifd[TIFF_TAG_COMPRESSION]?.[0];
+  if (cmpr === COMPRESSION_OLD_JPEG || cmpr === COMPRESSION_NEW_JPEG) return true;
+  return !!getIfdJpegPointer(ifd);
+}
+
+/**
+ * Pick the largest JPEG-compressed IFD (the camera-rendered preview).
+ * Exported for testing.
+ */
+export function pickLargestJpegIfd(ifds, arrayBuffer) {
   let best = null;
   let bestPixels = 0;
   for (const ifd of ifds) {
-    const cmprArr = ifd[TIFF_TAG_COMPRESSION];
-    const cmpr = Array.isArray(cmprArr) ? cmprArr[0] : null;
-    const hasJpegPointer = ifd[TIFF_TAG_JPEG_OFFSET] && ifd[TIFF_TAG_JPEG_LENGTH];
-    const isJpeg = cmpr === COMPRESSION_OLD_JPEG || cmpr === COMPRESSION_NEW_JPEG;
-    if (!isJpeg && !hasJpegPointer) continue;
-
-    const w = getIfdDim(ifd, TIFF_TAG_IMAGE_WIDTH);
-    const h = getIfdDim(ifd, TIFF_TAG_IMAGE_LENGTH);
-    if (w < MIN_PREVIEW_WIDTH) continue;
-
-    const pixels = w * h;
+    if (!isJpegIfd(ifd)) continue;
+    const dims = getIfdJpegDimensions(ifd, arrayBuffer);
+    if (!dims || dims.w < MIN_PREVIEW_WIDTH) continue;
+    const pixels = dims.w * dims.h;
     if (pixels > bestPixels) {
       bestPixels = pixels;
-      best = ifd;
+      best = { ifd, w: dims.w, h: dims.h, pointer: getIfdJpegPointer(ifd) };
     }
   }
   return best;
 }
 
 /**
- * Try to extract a usable embedded JPEG preview from a TIFF-based RAW (NEF, etc.).
- * Returns an `ImageData` on success, or `null` if no suitable preview was
- * found / decoding failed. Never throws.
+ * Find the embedded full-resolution JPEG preview inside a TIFF-based RAW
+ * (NEF, IIQ, etc.) and return its raw bytes plus dimensions, without
+ * decoding them. Pure synchronous parsing — usable from Node tests.
+ *
+ * @param {ArrayBuffer} arrayBuffer
+ * @returns {{ jpegBytes: Uint8Array, width: number, height: number } | null}
  */
-export function tryNefJpegPreview(arrayBuffer) {
+export function extractNefPreviewJpeg(arrayBuffer) {
   let topIfds;
   try {
     topIfds = UTIF.decode(arrayBuffer);
@@ -87,18 +182,67 @@ export function tryNefJpegPreview(arrayBuffer) {
   if (!Array.isArray(topIfds) || topIfds.length === 0) return null;
 
   const allIfds = collectAllIfds(topIfds);
-  const previewIfd = pickLargestJpegIfd(allIfds);
-  if (!previewIfd) return null;
+  const choice = pickLargestJpegIfd(allIfds, arrayBuffer);
+  if (!choice || !choice.pointer) return null;
+
+  const { offset, length } = choice.pointer;
+  if (offset < 0 || length <= 0 || offset + length > arrayBuffer.byteLength) return null;
+  // Slice into a fresh buffer so the caller can hand it to Blob/Worker
+  // without retaining the entire RAW container in memory.
+  const jpegBytes = new Uint8Array(arrayBuffer, offset, length);
+  return { jpegBytes, width: choice.w, height: choice.h };
+}
+
+/**
+ * Try to extract a usable embedded JPEG preview from a TIFF-based RAW (NEF, etc.)
+ * and decode it via the browser's native JPEG decoder. Returns an `ImageData`
+ * on success, or `null` if no suitable preview was found / decoding failed.
+ * Never throws.
+ *
+ * Async because `createImageBitmap` is async — callers (loadRawFile) already
+ * run inside an async function.
+ *
+ * @param {ArrayBuffer} arrayBuffer
+ * @returns {Promise<ImageData | null>}
+ */
+export async function tryNefJpegPreview(arrayBuffer) {
+  const extracted = extractNefPreviewJpeg(arrayBuffer);
+  if (!extracted) return null;
+  const { jpegBytes, width, height } = extracted;
+
+  // Hand the JPEG to the browser. Slice into a standalone ArrayBuffer so the
+  // Blob doesn't pin the whole RAW container.
+  let blob;
+  try {
+    const standalone = new Uint8Array(jpegBytes.byteLength);
+    standalone.set(jpegBytes);
+    blob = new Blob([standalone], { type: 'image/jpeg' });
+  } catch (err) {
+    console.warn('[NEF fallback] failed to wrap JPEG bytes:', err);
+    return null;
+  }
+
+  let bitmap;
+  try {
+    bitmap = await createImageBitmap(blob);
+  } catch (err) {
+    console.warn('[NEF fallback] createImageBitmap failed:', err);
+    return null;
+  }
 
   try {
-    UTIF.decodeImage(arrayBuffer, previewIfd, topIfds);
-    const rgba = UTIF.toRGBA8(previewIfd);
-    const w = previewIfd.width || getIfdDim(previewIfd, TIFF_TAG_IMAGE_WIDTH);
-    const h = previewIfd.height || getIfdDim(previewIfd, TIFF_TAG_IMAGE_LENGTH);
-    if (!w || !h || !rgba || rgba.length !== w * h * 4) return null;
-    return new ImageData(new Uint8ClampedArray(rgba), w, h);
+    const w = bitmap.width || width;
+    const h = bitmap.height || height;
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(bitmap, 0, 0);
+    return ctx.getImageData(0, 0, w, h);
   } catch (err) {
-    console.warn('[NEF fallback] UTIF.decodeImage failed:', err);
+    console.warn('[NEF fallback] canvas paint/getImageData failed:', err);
     return null;
+  } finally {
+    try { bitmap.close?.(); } catch {}
   }
 }

--- a/negative2positive/src/silvercore/util/jpegSize.test.mjs
+++ b/negative2positive/src/silvercore/util/jpegSize.test.mjs
@@ -1,0 +1,101 @@
+// Standalone Node test for the JPEG SOF marker parser inside nefJpegPreview.
+// Run with: node jpegSize.test.mjs
+//
+// We import readJpegDimensionsFromSOF directly to avoid pulling in `utif`
+// at module-load time (which expects a browser-ish environment in some paths).
+
+import assert from 'node:assert/strict';
+import { readJpegDimensionsFromSOF } from '../../app/nefJpegPreview.js';
+
+// Build a minimal valid JPEG: SOI + APP0 (ignored segment) + SOF0 + EOI.
+// SOF0 layout: FF C0 LL LL  P  HH HH WW WW NC ...
+function buildMiniJpeg(width, height) {
+  // SOF0 segment payload: precision(1) + height(2) + width(2) + components(1) + 3 bytes per component.
+  // We use 1 component for simplicity: total payload bytes = 1+2+2+1+3 = 9.
+  // segLen field includes its own 2 bytes → 11.
+  const sof = [
+    0xFF, 0xC0, 0x00, 0x0B,
+    0x08,
+    (height >> 8) & 0xFF, height & 0xFF,
+    (width >> 8) & 0xFF, width & 0xFF,
+    0x01,
+    0x01, 0x11, 0x00,
+  ];
+  // APP0 stub: FF E0 LL LL "JFIF\0" + payload (16 bytes total payload).
+  const app0 = [0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00,
+                0x01, 0x01, 0x00, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00];
+  const soi = [0xFF, 0xD8];
+  const eoi = [0xFF, 0xD9];
+  return new Uint8Array([...soi, ...app0, ...sof, ...eoi]);
+}
+
+// 1. Standard JPEG with SOF0 → returns correct dimensions
+{
+  const jpg = buildMiniJpeg(1234, 567);
+  const dims = readJpegDimensionsFromSOF(jpg.buffer, jpg.byteOffset, jpg.byteLength);
+  assert.deepEqual(dims, { w: 1234, h: 567 });
+}
+
+// 2. Embedded inside a larger buffer (simulating NEF: JPEG at non-zero offset)
+{
+  const jpg = buildMiniJpeg(800, 600);
+  const padded = new Uint8Array(jpg.length + 100);
+  padded.set(jpg, 50);  // place at offset 50
+  const dims = readJpegDimensionsFromSOF(padded.buffer, padded.byteOffset + 50, jpg.length);
+  assert.deepEqual(dims, { w: 800, h: 600 });
+}
+
+// 3. Large dimensions (full-resolution camera preview)
+{
+  const jpg = buildMiniJpeg(6064, 4040);
+  const dims = readJpegDimensionsFromSOF(jpg.buffer, jpg.byteOffset, jpg.byteLength);
+  assert.deepEqual(dims, { w: 6064, h: 4040 });
+}
+
+// 4. Non-JPEG input (TIFF magic) → null
+{
+  const tiff = new Uint8Array([0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00]);
+  assert.equal(readJpegDimensionsFromSOF(tiff.buffer, 0, tiff.length), null);
+}
+
+// 5. Empty / too-short buffer → null
+{
+  const empty = new Uint8Array(0);
+  assert.equal(readJpegDimensionsFromSOF(empty.buffer, 0, 0), null);
+  const tiny = new Uint8Array([0xFF, 0xD8]);
+  assert.equal(readJpegDimensionsFromSOF(tiny.buffer, 0, tiny.length), null);
+}
+
+// 6. Buffer truncated before SOF (only SOI + APP0 + EOI without SOF) → null
+{
+  const truncated = new Uint8Array([
+    0xFF, 0xD8,
+    0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00,
+    0x01, 0x01, 0x00, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00,
+    0xFF, 0xD9,
+  ]);
+  assert.equal(readJpegDimensionsFromSOF(truncated.buffer, 0, truncated.length), null);
+}
+
+// 7. Bad arguments → null (no throw)
+{
+  assert.equal(readJpegDimensionsFromSOF(null, 0, 0), null);
+  assert.equal(readJpegDimensionsFromSOF(new Uint8Array(20).buffer, -1, 10), null);
+  assert.equal(readJpegDimensionsFromSOF(new Uint8Array(20).buffer, 0, 0), null);
+}
+
+// 8. SOF2 (progressive) is also recognized
+{
+  const jpg = buildMiniJpeg(500, 400);
+  // mutate SOF0 (0xC0) to SOF2 (0xC2) — same payload layout
+  for (let i = 0; i < jpg.length - 1; i++) {
+    if (jpg[i] === 0xFF && jpg[i + 1] === 0xC0) {
+      jpg[i + 1] = 0xC2;
+      break;
+    }
+  }
+  const dims = readJpegDimensionsFromSOF(jpg.buffer, jpg.byteOffset, jpg.byteLength);
+  assert.deepEqual(dims, { w: 500, h: 400 });
+}
+
+console.log('jpegSize tests: all passed');

--- a/negative2positive/src/silvercore/util/nef-fixture.smoke.mjs
+++ b/negative2positive/src/silvercore/util/nef-fixture.smoke.mjs
@@ -1,0 +1,53 @@
+// Hard regression: PR #81's NEF fallback could not select a usable IFD on
+// `DSC_4127.NEF` because all of its embedded JPEG IFDs lacked t256/t257.
+// This smoke loads the real fixture and asserts the synchronous extraction
+// step (`extractNefPreviewJpeg`) finds a full-resolution preview. The actual
+// JPEG decode happens in the browser via `createImageBitmap` and isn't
+// exercised here — but if extraction returns the right offset/size with
+// the right SOF dimensions, the browser layer is trivial to verify.
+//
+// Run: node negative2positive/src/silvercore/util/nef-fixture.smoke.mjs
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const { extractNefPreviewJpeg } = await import('../../app/nefJpegPreview.js');
+
+const FIXTURE = path.resolve(process.cwd(), 'DSC_4127.NEF');
+if (!fs.existsSync(FIXTURE)) {
+  console.warn(`[skip] ${FIXTURE} not found — drop a Nikon Z f NEF here to run this smoke`);
+  process.exit(0);
+}
+
+const buf = fs.readFileSync(FIXTURE);
+const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+
+console.log(`Input: ${path.basename(FIXTURE)} (${(buf.byteLength / 1024 / 1024).toFixed(1)} MB)`);
+
+const start = Date.now();
+const extracted = extractNefPreviewJpeg(arrayBuffer);
+const elapsed = Date.now() - start;
+
+console.log(`extractNefPreviewJpeg returned in ${elapsed}ms`);
+
+assert.ok(extracted, 'extractNefPreviewJpeg returned null — IFD selection still broken');
+assert.ok(extracted.jpegBytes instanceof Uint8Array, 'jpegBytes is not Uint8Array');
+assert.ok(extracted.jpegBytes.byteLength > 100_000, `jpeg too small: ${extracted.jpegBytes.byteLength} bytes — likely picked a thumbnail`);
+
+// Verify it's actually a JPEG (SOI marker)
+assert.equal(extracted.jpegBytes[0], 0xFF, 'first byte is not 0xFF');
+assert.equal(extracted.jpegBytes[1], 0xD8, 'second byte is not 0xD8 (not a JPEG)');
+
+assert.ok(extracted.width >= 1000, `expected width >= 1000, got ${extracted.width}`);
+assert.ok(extracted.height >= 700, `expected height >= 700, got ${extracted.height}`);
+
+// Sanity: the embedded camera preview should be at least 1/4 the original 6064x4040
+// RAW resolution. If we accidentally selected a thumbnail, this catches it.
+const RAW_PIXELS = 6064 * 4040;
+const previewPixels = extracted.width * extracted.height;
+const ratio = previewPixels / RAW_PIXELS;
+console.log(`Output: ${extracted.width}×${extracted.height} (${(ratio * 100).toFixed(1)}% of raw resolution, ${(extracted.jpegBytes.byteLength / 1024 / 1024).toFixed(2)} MB JPEG)`);
+assert.ok(ratio >= 0.5, `preview ratio ${ratio.toFixed(2)} suggests we picked the wrong IFD`);
+
+console.log('✓ DSC_4127.NEF smoke passed — extracted full-resolution preview JPEG');


### PR DESCRIPTION
## Summary
PR #81's NEF "colorful snow" fallback could not actually select an IFD on real Nikon Z f files (`DSC_4127.NEF`). Two compounding bugs:

1. **`pickLargestJpegIfd` filtered out everything**. It required `t256`/`t257` on each IFD to clear the 1000 px minimum, but Z f's preview IFDs omit those tags entirely — dimensions live only inside the JPEG byte stream's SOF marker. All candidates returned 0, all got filtered, fallback returned `null`, user kept seeing snow.
2. **`UTIF.decodeImage` silently no-ops** on the JPEG-only IFD shape Z f uses (only `t513`/`t514`, no `t256`/`t257`/`t258`/strips). Even when we did pass it the right IFD it returned a zero-length buffer.

This PR fixes both:

### 1. SOF marker parser (10 LOC)
`readJpegDimensionsFromSOF` walks the JPEG marker chain to read true dimensions when `t256`/`t257` are missing.

### 2. Skip UTIF for preview decode
We now extract the JPEG bytes out of the container and hand them to the browser's native `createImageBitmap`, then paint to canvas for `ImageData`. Browser JPEG decoding is more reliable than UTIF's strip-based path on these IFDs.

`tryNefJpegPreview` is now async (`createImageBitmap` is a promise); all three call sites in `loadRawFile` are inside async functions, just needed `await`.

## Hard regression: `DSC_4127.NEF`
```
Input: DSC_4127.NEF (17.5 MB)
extractNefPreviewJpeg returned in 2ms
Output: 6048×4032 (99.5% of raw resolution, 1.59 MB JPEG)
✓ DSC_4127.NEF smoke passed — extracted full-resolution preview JPEG
```

## Test plan
- [x] `npm run build:web` clean
- [x] `jpegSize.test.mjs` — 8 cases (valid SOF / non-JPEG / truncated / SOF2 progressive / bad args) all pass
- [x] `nef-fixture.smoke.mjs` on real `DSC_4127.NEF` — extracts 6048×4032 preview (99.5% of RAW)
- [x] `garbledCheck.test.mjs` + `image16.test.mjs` regression — pass
- [ ] Manual: `_DSC3111.NEF` (lossless compressed) — should still hit LibRaw main path, no fallback
- [ ] Manual: `DSC_4127.NEF` upload — should now show a real preview image instead of colorful snow

🤖 Generated with [Claude Code](https://claude.com/claude-code)