### PR TITLE
Make NEF preview fallback actually fire on Nikon Z f files

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -6314,8 +6314,13 @@
       };
 
       try {
+        // libraw-wasm transfers the typed array's underlying buffer to its
+        // worker, which detaches the original ArrayBuffer on the main thread.
+        // We need `buffer` intact for the fallback path (UTIF), so hand
+        // LibRaw an independent copy.
+        const libRawInput = new Uint8Array(buffer.slice(0));
         await withTimeout(
-          raw.open(new Uint8Array(buffer), {
+          raw.open(libRawInput, {
             noInterpolation: false,
             useAutoWb: true,
             useCameraWb: true,

--- a/negative2positive/src/silvercore/util/garbledCheck.js
+++ b/negative2positive/src/silvercore/util/garbledCheck.js
@@ -7,43 +7,62 @@
 // Heuristic: in any real photograph (including film negatives), neighboring
 // pixels are strongly correlated, so |pixel - neighbor| is small. In Bayer
 // snow, neighbors are nearly independent and the mean absolute neighbor
-// difference approaches ~1/3 of full range. We sample 1024 points and
-// declare snow when that mean exceeds 25% of full range (very conservative
-// — even noisy high-ISO film negatives stay well under 10%).
+// difference is close to ~1/3 of full range.
+//
+// We sample over a 4×4 tile grid and take the MAX tile mean rather than the
+// global mean. This catches partial garble — when LibRaw aborts mid-decode
+// it often emits a buffer with one half noisy and the other half a flat
+// fallback color (Nikon Z f HE mode does this with "data corrupted at N").
+// A global mean would average those into a normal-looking number; per-tile
+// max pinpoints the noisy region.
 
-const SAMPLE_COUNT = 1024;
-const SNOW_THRESHOLD_RATIO = 0.25;
+const TILES_PER_AXIS = 4;          // 4×4 = 16 tiles
+const SAMPLES_PER_TILE = 64;       // ~1024 total samples
+// Per-tile mean above 15% of full range = garbled. Calibrated against real
+// Nikon Z f HE-mode failure (DSC_4127.NEF) where the noisiest tile averages
+// ~16%. Drops well above any realistic film-negative tile mean (sharp
+// 4-row banding pattern in the test suite peaks around 10%).
+const SNOW_THRESHOLD_RATIO = 0.15;
 
 export function looksLikeBayerSnow(image16) {
   if (!image16 || !image16.data || !image16.width || !image16.height) return false;
   const { width, height, data } = image16;
-  if (width < 4 || height < 4) return false;
+  if (width < 16 || height < 16) return false;
 
   const maxValue = data instanceof Uint16Array ? 65535 : 255;
   const threshold = maxValue * SNOW_THRESHOLD_RATIO;
 
-  // Stride-based pseudo-random sampling — covers the full image without RNG.
-  // Stay one pixel inside the right/bottom edges so we always have a right and
-  // down neighbor.
-  const innerW = width - 1;
-  const innerH = height - 1;
-  const total = innerW * innerH;
-  const stride = Math.max(1, Math.floor(total / SAMPLE_COUNT));
+  let maxTileMean = 0;
+  for (let ty = 0; ty < TILES_PER_AXIS; ty++) {
+    for (let tx = 0; tx < TILES_PER_AXIS; tx++) {
+      const x0 = Math.floor((tx * width) / TILES_PER_AXIS);
+      const x1 = Math.min(width - 1, Math.floor(((tx + 1) * width) / TILES_PER_AXIS));
+      const y0 = Math.floor((ty * height) / TILES_PER_AXIS);
+      const y1 = Math.min(height - 1, Math.floor(((ty + 1) * height) / TILES_PER_AXIS));
+      const innerW = x1 - x0;
+      const innerH = y1 - y0;
+      if (innerW < 2 || innerH < 2) continue;
+      const total = innerW * innerH;
+      const stride = Math.max(1, Math.floor(total / SAMPLES_PER_TILE));
 
-  let sum = 0;
-  let count = 0;
-  for (let s = 0; s < total && count < SAMPLE_COUNT; s += stride) {
-    const x = s % innerW;
-    const y = (s / innerW) | 0;
-    const i = (y * width + x) * 4;
-    const r = data[i];
-    const rRight = data[i + 4];          // pixel to the right, R channel
-    const rDown = data[i + width * 4];   // pixel below, R channel
-    sum += Math.abs(r - rRight) + Math.abs(r - rDown);
-    count++;
+      let sum = 0;
+      let count = 0;
+      for (let s = 0; s < total && count < SAMPLES_PER_TILE; s += stride) {
+        const lx = s % innerW;
+        const ly = (s / innerW) | 0;
+        const x = x0 + lx;
+        const y = y0 + ly;
+        if (x + 1 >= width || y + 1 >= height) continue;
+        const i = (y * width + x) * 4;
+        const r = data[i];
+        sum += Math.abs(r - data[i + 4]) + Math.abs(r - data[i + width * 4]);
+        count++;
+      }
+      if (count === 0) continue;
+      const mean = sum / (count * 2);
+      if (mean > maxTileMean) maxTileMean = mean;
+    }
   }
-  if (count === 0) return false;
 
-  const mean = sum / (count * 2);
-  return mean > threshold;
+  return maxTileMean > threshold;
 }

--- a/negative2positive/src/silvercore/util/garbledCheck.test.mjs
+++ b/negative2positive/src/silvercore/util/garbledCheck.test.mjs
@@ -76,4 +76,49 @@ function make(width, height, fill) {
   assert.equal(looksLikeBayerSnow({ width: 2, height: 2, data: new Uint16Array(16) }), false, 'tiny image returns false safely');
 }
 
+// 7. Partial garble: top half noise, bottom half flat fill
+//    This mimics Nikon Z f HE-mode failure — LibRaw aborts with
+//    "data corrupted at N" and emits a buffer where the lower portion
+//    is left as a flat sentinel color. Global-mean checks miss this.
+{
+  const w = 64, h = 64;
+  const data = new Uint16Array(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      if (y < h / 2) {
+        // noisy region
+        data[i]     = (Math.random() * 65536) | 0;
+        data[i + 1] = (Math.random() * 65536) | 0;
+        data[i + 2] = (Math.random() * 65536) | 0;
+      } else {
+        // flat pink fill (~ 60% red, 30% green, 50% blue)
+        data[i]     = 39000;
+        data[i + 1] = 19000;
+        data[i + 2] = 32000;
+      }
+      data[i + 3] = 65535;
+    }
+  }
+  assert.equal(looksLikeBayerSnow({ width: w, height: h, data }), true, 'partial garble must be flagged');
+}
+
+// 8. Sharp edges in a normal photo (high-frequency detail) → not flagged
+//    Builds a high-detail-but-coherent test pattern: alternating bright/dim
+//    rows with smooth gradients within each row. Mimics noisy texture
+//    without true noise. Real noisy negatives stay below 10%.
+{
+  const w = 64, h = 64;
+  const data = new Uint16Array(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    const isBright = (y >> 2) & 1;
+    for (let x = 0; x < w; x++) {
+      const v = (isBright ? 50000 : 12000) + Math.round(2000 * Math.sin(x * 0.1));
+      const i = (y * w + x) * 4;
+      data[i] = v; data[i + 1] = v; data[i + 2] = v; data[i + 3] = 65535;
+    }
+  }
+  assert.equal(looksLikeBayerSnow({ width: w, height: h, data }), false, 'sharp-edge photo should not be flagged');
+}
+
 console.log('garbledCheck tests: all passed');


### PR DESCRIPTION
## Summary
PR #83 added the NEF embedded-preview fallback but two real-world bugs kept it from running on `DSC_4127.NEF`. Verified end-to-end via Chrome DevTools MCP: file now decodes to a real 6048×4032 image instead of colorful snow.

## Bug 1 — sanity check missed partial garble
LibRaw on Z f HE-mode emits `unknown file: data corrupted at N` mid-decode and returns a buffer where roughly the upper half is colorful snow and the lower half is a flat sentinel color. The previous global-mean detector averaged those together (~7% of full range) and never crossed the 25% threshold.

**Fix**: sample over a **4×4 grid** and use the **MAX tile mean** as the judgment. Also calibrated threshold **0.25 → 0.15** against real data — DSC_4127's noisiest tile averages 16%, sharp-edge negatives stay <11%. Added a partial-garble test case + a sharp-edge non-regression case.

## Bug 2 — ArrayBuffer detached before fallback could read it
`raw.open(new Uint8Array(buffer), …)` shares the original ArrayBuffer. Inside libraw-wasm, the worker `postMessage` lists that buffer in the transferList → main-thread buffer becomes detached → by the time fallback fires and calls `tryNefJpegPreview(buffer)`, UTIF.decode throws "Cannot perform Construct on a detached ArrayBuffer".

**Fix**: hand LibRaw an independent `buffer.slice(0)` copy. Original `buffer` stays intact for fallback.

## Test plan
- [x] `npm run build:web` clean
- [x] All unit tests pass: `garbledCheck` (8 cases), `jpegSize` (8 cases), `image16` (9 cases), `nef-fixture` smoke
- [x] **Live browser test via Chrome DevTools MCP**: uploaded `DSC_4127.NEF`, console shows fallback firing and preview decoded. Screenshot of the rendered black-and-white negative attached to PR #83 follow-up notes.

## Console trace (success)
```
[RAW] {make:'NIKON', model:'NIKON Z f', ...}
[error] unknown file: data corrupted at 3010052     ← LibRaw's own error
[warn] [RAW] decoded output looks un-demosaiced; trying embedded JPEG preview fallback
[warn] [RAW] embedded preview decoded — precision is downgraded to 8-bit for this file.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)