### PR TITLE
fix: stream web batch zip export

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -23,6 +23,7 @@
     } from '../silvercore/util/image16.js';
     import { looksLikeBayerSnow } from '../silvercore/util/garbledCheck.js';
     import { tryNefJpegPreview } from './nefJpegPreview.js';
+    import { canUseBrowserZipStreaming, ZipStoreWriter } from './zipStoreWriter.js';
     import { Histogram } from '../silvercore/ui/Histogram.js';
     import {
       detectDust, updateDustStrength, inpaintMasked,
@@ -338,6 +339,10 @@
         zipSavedTo: "ZIP 已保存到：\n{path}",
         zipSaveCancelled: "已取消 ZIP 保存，未写出文件。",
         zipDownloadStarted: "ZIP 下载已开始，请检查浏览器下载目录。",
+        zipStreamingSaved: "ZIP 已保存：{file}。成功导出 {success} / {total} 个文件。",
+        zipStreamingPartial: "ZIP 已保存：{file}。成功导出 {success} / {total} 个文件，失败 {failed} 个。",
+        zipStreamingCancelled: "已取消 ZIP 保存，未开始批量处理。",
+        zipStreamingUnsupportedFallback: "当前浏览器不支持安全的 ZIP 流式保存，将改为逐个下载全部文件。",
         batchDownloadCancelled: "已取消后续导出。已经保存的文件会保留。",
         desktopBatchExportProgress: "导出中 {current} / {total}",
         desktopBatchExportFolderCancelled: "已取消选择导出文件夹。",
@@ -678,6 +683,10 @@
         zipSavedTo: "ZIP saved to:\n{path}",
         zipSaveCancelled: "ZIP save cancelled. No file was written.",
         zipDownloadStarted: "ZIP download started. Check your Downloads folder.",
+        zipStreamingSaved: "ZIP saved: {file}. Exported {success} / {total} files.",
+        zipStreamingPartial: "ZIP saved: {file}. Exported {success} / {total} files; {failed} failed.",
+        zipStreamingCancelled: "ZIP save cancelled before batch processing started.",
+        zipStreamingUnsupportedFallback: "This browser cannot stream ZIP saves safely, so files will download individually instead.",
         batchDownloadCancelled: "Batch export cancelled. Files already saved were kept.",
         desktopBatchExportProgress: "Exporting {current} / {total}",
         desktopBatchExportFolderCancelled: "Folder selection cancelled. No files were exported.",
@@ -1018,6 +1027,10 @@
         zipSavedTo: "ZIP を保存しました:\n{path}",
         zipSaveCancelled: "ZIP の保存をキャンセルしました。ファイルは書き出されていません。",
         zipDownloadStarted: "ZIP のダウンロードを開始しました。ダウンロードフォルダを確認してください。",
+        zipStreamingSaved: "ZIP を保存しました: {file}。{success} / {total} 件を書き出しました。",
+        zipStreamingPartial: "ZIP を保存しました: {file}。{success} / {total} 件を書き出し、{failed} 件が失敗しました。",
+        zipStreamingCancelled: "ZIP 保存がキャンセルされたため、バッチ処理は開始していません。",
+        zipStreamingUnsupportedFallback: "このブラウザでは安全な ZIP ストリーミング保存が使えないため、各ファイルを個別にダウンロードします。",
         batchDownloadCancelled: "以降の書き出しをキャンセルしました。保存済みのファイルは保持されます。",
         desktopBatchExportProgress: "書き出し中 {current} / {total}",
         desktopBatchExportFolderCancelled: "出力フォルダの選択をキャンセルしました。",
@@ -9701,6 +9714,35 @@
       return { saved: true, path: null };
     }
 
+    function isBrowserSavePickerCancel(err) {
+      return Boolean(err && (
+        err.name === 'AbortError'
+        || err.code === 20
+      ));
+    }
+
+    async function createBrowserZipWritable(zipFileName) {
+      if (!canUseBrowserZipStreaming(window)) {
+        return null;
+      }
+
+      const handle = await window.showSaveFilePicker({
+        suggestedName: zipFileName,
+        types: [{
+          description: 'ZIP archive',
+          accept: { 'application/zip': ['.zip'] }
+        }]
+      });
+      if (!handle || typeof handle.createWritable !== 'function') {
+        return null;
+      }
+
+      return {
+        fileName: handle.name || zipFileName,
+        writable: await handle.createWritable()
+      };
+    }
+
     function canvasToBlobWithType(targetCanvas, mimeType, quality) {
       return new Promise((resolve, reject) => {
         targetCanvas.toBlob((blob) => {
@@ -10626,16 +10668,27 @@
       return applyAdjustmentsWithSettings(processed, settings);
     }
 
-    // Streaming ZIP export: process → add to zip → free memory → next
-    async function exportBatchAsZip() {
-      const selectedFiles = getSelectedFiles();
-      if (selectedFiles.length < 1) return;
+    function showBrowserZipStreamSummary({ zipFileName, successCount, failCount, total }) {
+      const key = failCount > 0 ? 'zipStreamingPartial' : 'zipStreamingSaved';
+      const fallback = failCount > 0
+        ? `ZIP saved: ${zipFileName}. Exported ${successCount} / ${total} files; ${failCount} failed.`
+        : `ZIP saved: ${zipFileName}. Exported ${successCount} / ${total} files.`;
+      showToast(
+        getInterpolatedText(key, {
+          file: zipFileName,
+          success: successCount,
+          failed: failCount,
+          total
+        }, fallback),
+        failCount > 0 ? 6000 : 4500
+      );
+    }
 
+    async function exportBatchAsZipDesktop(selectedFiles, zipFileName) {
       if (typeof JSZipCtor !== 'function') {
         throw new Error('JSZip module is unavailable');
       }
 
-      const zipFileName = 'converted_negatives.zip';
       let desktopZipTargetPath = null;
       if (isTauriDesktop()) {
         // Pick the destination before the long-running batch starts so macOS can
@@ -10714,6 +10767,166 @@
       } finally {
         overlay.hide();
       }
+    }
+
+    async function exportBatchAsZipBrowser(selectedFiles, zipFileName) {
+      if (!canUseBrowserZipStreaming(window)) {
+        showToast(
+          getLocalizedText(
+            'zipStreamingUnsupportedFallback',
+            'This browser cannot stream ZIP saves safely, so files will download individually instead.'
+          ),
+          5000
+        );
+        await exportBatchIndividuallyBrowser();
+        return;
+      }
+
+      let streamTarget;
+      try {
+        streamTarget = await createBrowserZipWritable(zipFileName);
+      } catch (err) {
+        if (isBrowserSavePickerCancel(err)) {
+          showToast(
+            getLocalizedText(
+              'zipStreamingCancelled',
+              'ZIP save cancelled before batch processing started.'
+            ),
+            3500
+          );
+          return;
+        }
+        throw err;
+      }
+
+      if (!streamTarget || !streamTarget.writable) {
+        showToast(
+          getLocalizedText(
+            'zipStreamingUnsupportedFallback',
+            'This browser cannot stream ZIP saves safely, so files will download individually instead.'
+          ),
+          5000
+        );
+        await exportBatchIndividuallyBrowser();
+        return;
+      }
+
+      const exportInfo = getExportInfo();
+      const lang = i18n[currentLang];
+      const overlay = getLoadingOverlay();
+      const total = selectedFiles.length;
+      let successCount = 0;
+      let failCount = 0;
+      let zipWriter = null;
+
+      await overlay.show({ title: lang.loadingExporting });
+
+      try {
+        zipWriter = new ZipStoreWriter(streamTarget.writable);
+
+        for (let i = 0; i < selectedFiles.length; i++) {
+          const { item, index } = selectedFiles[i];
+          const fileProgress = (i / total) * 95;
+          const fileSlice = 95 / total;
+          let adjusted = null;
+          let blob = null;
+          let name = '';
+
+          item.status = 'processing';
+          item.error = null;
+          updateFileListUI();
+          overlay.updateProgress(
+            fileProgress,
+            lang.loadingBatchFile.replace('{current}', i + 1).replace('{total}', total)
+          );
+
+          try {
+            const settingsForFile = getSettingsForExport(index, item);
+            adjusted = await processFileWithSettings(item.file, settingsForFile);
+            overlay.updateProgress(fileProgress + fileSlice * 0.55, lang.loadingEncoding);
+            blob = await imageDataToBlob(
+              adjusted,
+              exportInfo.format,
+              state.jpegQuality,
+              exportInfo.bitDepth,
+              (pct) => {
+                overlay.updateProgress(
+                  fileProgress + fileSlice * (0.55 + pct * 0.25),
+                  lang.loadingEncoding
+                );
+              }
+            );
+            name = buildExportFileName(item.file.name, exportInfo);
+          } catch (err) {
+            console.error(`Error processing ${item.file.name}:`, err);
+            item.status = 'error';
+            item.error = err && err.message ? err.message : String(err || 'Unknown error');
+            failCount++;
+            updateFileListUI();
+            overlay.updateProgress(
+              fileProgress + fileSlice,
+              lang.loadingBatchFile.replace('{current}', i + 1).replace('{total}', total)
+            );
+            adjusted = null;
+            blob = null;
+            await waitForNextFrame();
+            continue;
+          }
+
+          try {
+            overlay.updateProgress(fileProgress + fileSlice * 0.86, lang.loadingBatchZip);
+            await zipWriter.addBlob(name, blob);
+            item.status = 'done';
+            item.error = null;
+            successCount++;
+          } finally {
+            adjusted = null;
+            blob = null;
+          }
+
+          updateFileListUI();
+          overlay.updateProgress(
+            fileProgress + fileSlice,
+            lang.loadingBatchFile.replace('{current}', i + 1).replace('{total}', total)
+          );
+          await waitForNextFrame();
+        }
+
+        overlay.updateProgress(98, lang.loadingBatchZip);
+        await zipWriter.close();
+        zipWriter = null;
+        overlay.updateProgress(100, lang.loadingComplete);
+        showBrowserZipStreamSummary({
+          zipFileName: streamTarget.fileName || zipFileName,
+          successCount,
+          failCount,
+          total
+        });
+      } catch (err) {
+        if (zipWriter) {
+          try {
+            await zipWriter.abort();
+          } catch (abortErr) {
+            console.warn('Failed to abort ZIP stream:', abortErr);
+          }
+        }
+        throw err;
+      } finally {
+        overlay.hide();
+      }
+    }
+
+    async function exportBatchAsZip() {
+      const selectedFiles = getSelectedFiles();
+      if (selectedFiles.length < 1) return;
+
+      const zipFileName = 'converted_negatives.zip';
+      if (isTauriDesktop()) {
+        await exportBatchAsZipDesktop(selectedFiles, zipFileName);
+        return;
+      }
+
+      await exportBatchAsZipBrowser(selectedFiles, zipFileName);
     }
 
     function createBatchExportJobs(selectedFiles, exportInfo) {
@@ -10875,7 +11088,6 @@
       if (selectedFiles.length < 1) return;
 
       const exportInfo = getExportInfo();
-      let processedCount = 0;
       let cancelledByUser = false;
       const lang = i18n[currentLang];
       const overlay = getLoadingOverlay();
@@ -10884,26 +11096,37 @@
       await overlay.show({ title: lang.loadingExporting });
 
       try {
-        for (const { item, index } of selectedFiles) {
-          item.status = 'processing';
-          updateFileListUI();
-          processedCount++;
-          const fileProgress = ((processedCount - 1) / total) * 100;
+        for (let i = 0; i < selectedFiles.length; i++) {
+          const { item, index } = selectedFiles[i];
+          const fileProgress = (i / total) * 100;
           const fileSlice = 100 / total;
-          overlay.updateProgress(fileProgress, lang.loadingBatchFile.replace('{current}', processedCount).replace('{total}', total));
+          let adjusted = null;
+          let blob = null;
+          let name = '';
+
+          item.status = 'processing';
+          item.error = null;
+          updateFileListUI();
+          overlay.updateProgress(fileProgress, lang.loadingBatchFile.replace('{current}', i + 1).replace('{total}', total));
 
           try {
             const settingsForFile = getSettingsForExport(index, item);
-            const adjusted = await processFileWithSettings(item.file, settingsForFile);
+            adjusted = await processFileWithSettings(item.file, settingsForFile);
             overlay.updateProgress(fileProgress + fileSlice * 0.6, lang.loadingEncoding);
-            const blob = await imageDataToBlob(
+            blob = await imageDataToBlob(
               adjusted,
               exportInfo.format,
               state.jpegQuality,
-              exportInfo.bitDepth
+              exportInfo.bitDepth,
+              (pct) => {
+                overlay.updateProgress(
+                  fileProgress + fileSlice * (0.6 + pct * 0.3),
+                  lang.loadingEncoding
+                );
+              }
             );
 
-            const name = buildExportFileName(item.file.name, exportInfo);
+            name = buildExportFileName(item.file.name, exportInfo);
             overlay.hide(); // Hide overlay before save dialog
             const result = await saveBlob(blob, name, exportInfo.mimeType);
             if (!result.saved) {
@@ -10914,18 +11137,25 @@
               break;
             }
             // Re-show overlay for next file
-            if (processedCount < total) {
+            if (i + 1 < total) {
               await overlay.show({ title: lang.loadingExporting });
             }
 
             item.status = 'done';
+            item.error = null;
           } catch (err) {
             console.error(`Error processing ${item.file.name}:`, err);
             item.status = 'error';
+            item.error = err && err.message ? err.message : String(err || 'Unknown error');
+          } finally {
+            adjusted = null;
+            blob = null;
+            name = '';
           }
 
           updateFileListUI();
-          await new Promise(r => setTimeout(r, 100));
+          overlay.updateProgress(fileProgress + fileSlice, lang.loadingBatchFile.replace('{current}', i + 1).replace('{total}', total));
+          await waitForNextFrame();
         }
         if (cancelledByUser) {
           console.info('Batch individual export cancelled by user.');

--- a/negative2positive/src/app/zipStoreWriter.js
+++ b/negative2positive/src/app/zipStoreWriter.js
@@ -1,0 +1,251 @@
+const ZIP_MAX_U16 = 0xFFFF;
+const ZIP_MAX_U32 = 0xFFFFFFFF;
+const ZIP_VERSION_NEEDED = 20;
+const ZIP_GENERAL_PURPOSE_UTF8 = 0x0800;
+const ZIP_METHOD_STORE = 0;
+
+const textEncoder = new TextEncoder();
+
+const crc32Table = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function ensureZipU16(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > ZIP_MAX_U16) {
+    throw new Error(`${label} exceeds the ZIP32 limit.`);
+  }
+  return value;
+}
+
+function ensureZipU32(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > ZIP_MAX_U32) {
+    throw new Error(`${label} exceeds the ZIP32 limit.`);
+  }
+  return value;
+}
+
+function normalizeZipEntryName(name) {
+  const normalized = String(name || 'export.bin').replace(/\\/g, '/');
+  const parts = normalized
+    .split('/')
+    .filter(part => part && part !== '.' && part !== '..');
+  return parts.length ? parts.join('/') : 'export.bin';
+}
+
+function encodeEntryName(name) {
+  const bytes = textEncoder.encode(normalizeZipEntryName(name));
+  ensureZipU16(bytes.length, 'ZIP entry name length');
+  return bytes;
+}
+
+function toUint8Array(chunk) {
+  if (chunk instanceof Uint8Array) return chunk;
+  if (chunk instanceof ArrayBuffer) return new Uint8Array(chunk);
+  if (ArrayBuffer.isView(chunk)) {
+    return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  }
+  throw new Error('Unsupported ZIP stream chunk type.');
+}
+
+async function* readBlobChunks(blob) {
+  if (blob && typeof blob.stream === 'function') {
+    const reader = blob.stream().getReader();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) yield toUint8Array(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    return;
+  }
+
+  if (blob && typeof blob.arrayBuffer === 'function') {
+    yield new Uint8Array(await blob.arrayBuffer());
+    return;
+  }
+
+  throw new Error('ZIP entry payload is not a Blob.');
+}
+
+async function crc32OfBlob(blob) {
+  let crc = 0xFFFFFFFF;
+  for await (const chunk of readBlobChunks(blob)) {
+    for (let i = 0; i < chunk.length; i++) {
+      crc = crc32Table[(crc ^ chunk[i]) & 0xFF] ^ (crc >>> 8);
+    }
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+function getDosDateTime(date = new Date()) {
+  const safeDate = date instanceof Date && Number.isFinite(date.getTime()) ? date : new Date();
+  const year = Math.max(1980, Math.min(2107, safeDate.getFullYear()));
+  const month = Math.max(1, Math.min(12, safeDate.getMonth() + 1));
+  const day = Math.max(1, Math.min(31, safeDate.getDate()));
+  const hours = Math.max(0, Math.min(23, safeDate.getHours()));
+  const minutes = Math.max(0, Math.min(59, safeDate.getMinutes()));
+  const seconds = Math.max(0, Math.min(58, Math.floor(safeDate.getSeconds() / 2) * 2));
+
+  return {
+    time: (hours << 11) | (minutes << 5) | (seconds / 2),
+    date: ((year - 1980) << 9) | (month << 5) | day
+  };
+}
+
+function createLocalFileHeader(entry) {
+  const header = new Uint8Array(30 + entry.nameBytes.length);
+  const view = new DataView(header.buffer);
+  view.setUint32(0, 0x04034B50, true);
+  view.setUint16(4, ZIP_VERSION_NEEDED, true);
+  view.setUint16(6, ZIP_GENERAL_PURPOSE_UTF8, true);
+  view.setUint16(8, ZIP_METHOD_STORE, true);
+  view.setUint16(10, entry.dosTime, true);
+  view.setUint16(12, entry.dosDate, true);
+  view.setUint32(14, entry.crc32, true);
+  view.setUint32(18, entry.size, true);
+  view.setUint32(22, entry.size, true);
+  view.setUint16(26, entry.nameBytes.length, true);
+  view.setUint16(28, 0, true);
+  header.set(entry.nameBytes, 30);
+  return header;
+}
+
+function createCentralDirectoryHeader(entry) {
+  const header = new Uint8Array(46 + entry.nameBytes.length);
+  const view = new DataView(header.buffer);
+  view.setUint32(0, 0x02014B50, true);
+  view.setUint16(4, ZIP_VERSION_NEEDED, true);
+  view.setUint16(6, ZIP_VERSION_NEEDED, true);
+  view.setUint16(8, ZIP_GENERAL_PURPOSE_UTF8, true);
+  view.setUint16(10, ZIP_METHOD_STORE, true);
+  view.setUint16(12, entry.dosTime, true);
+  view.setUint16(14, entry.dosDate, true);
+  view.setUint32(16, entry.crc32, true);
+  view.setUint32(20, entry.size, true);
+  view.setUint32(24, entry.size, true);
+  view.setUint16(28, entry.nameBytes.length, true);
+  view.setUint16(30, 0, true);
+  view.setUint16(32, 0, true);
+  view.setUint16(34, 0, true);
+  view.setUint16(36, 0, true);
+  view.setUint32(38, 0, true);
+  view.setUint32(42, entry.localHeaderOffset, true);
+  header.set(entry.nameBytes, 46);
+  return header;
+}
+
+function createEndOfCentralDirectory(entryCount, centralDirectorySize, centralDirectoryOffset) {
+  ensureZipU16(entryCount, 'ZIP entry count');
+  ensureZipU32(centralDirectorySize, 'ZIP central directory size');
+  ensureZipU32(centralDirectoryOffset, 'ZIP central directory offset');
+
+  const header = new Uint8Array(22);
+  const view = new DataView(header.buffer);
+  view.setUint32(0, 0x06054B50, true);
+  view.setUint16(4, 0, true);
+  view.setUint16(6, 0, true);
+  view.setUint16(8, entryCount, true);
+  view.setUint16(10, entryCount, true);
+  view.setUint32(12, centralDirectorySize, true);
+  view.setUint32(16, centralDirectoryOffset, true);
+  view.setUint16(20, 0, true);
+  return header;
+}
+
+export function canUseBrowserZipStreaming(globalObject = globalThis) {
+  return Boolean(
+    globalObject
+    && typeof globalObject.showSaveFilePicker === 'function'
+  );
+}
+
+export class ZipStoreWriter {
+  constructor(writable, options = {}) {
+    if (!writable || typeof writable.write !== 'function') {
+      throw new Error('A writable file stream is required for ZIP export.');
+    }
+    this.writable = writable;
+    this.entries = [];
+    this.position = 0;
+    this.closed = false;
+    this.now = options.now instanceof Date ? options.now : null;
+  }
+
+  async writeChunk(chunk) {
+    const bytes = toUint8Array(chunk);
+    ensureZipU32(this.position + bytes.byteLength, 'ZIP archive size');
+    await this.writable.write(bytes);
+    this.position += bytes.byteLength;
+  }
+
+  async addBlob(name, blob) {
+    if (this.closed) throw new Error('ZIP writer is already closed.');
+    if (!(blob instanceof Blob)) {
+      throw new Error('ZIP entry payload is not a Blob.');
+    }
+    ensureZipU16(this.entries.length + 1, 'ZIP entry count');
+
+    const size = ensureZipU32(blob.size, 'ZIP entry size');
+    const crc32 = await crc32OfBlob(blob);
+    const { time, date } = getDosDateTime(this.now || new Date());
+    const nameBytes = encodeEntryName(name);
+    ensureZipU32(this.position + 30 + nameBytes.length + size, 'ZIP archive size');
+    const entry = {
+      nameBytes,
+      size,
+      crc32,
+      dosTime: time,
+      dosDate: date,
+      localHeaderOffset: ensureZipU32(this.position, 'ZIP local header offset')
+    };
+
+    await this.writeChunk(createLocalFileHeader(entry));
+    for await (const chunk of readBlobChunks(blob)) {
+      await this.writeChunk(chunk);
+    }
+    this.entries.push(entry);
+  }
+
+  async close() {
+    if (this.closed) return;
+
+    const centralDirectoryOffset = ensureZipU32(this.position, 'ZIP central directory offset');
+    let centralDirectorySize = 0;
+    for (const entry of this.entries) {
+      const header = createCentralDirectoryHeader(entry);
+      centralDirectorySize += header.byteLength;
+      ensureZipU32(centralDirectorySize, 'ZIP central directory size');
+      await this.writeChunk(header);
+    }
+
+    await this.writeChunk(createEndOfCentralDirectory(
+      this.entries.length,
+      centralDirectorySize,
+      centralDirectoryOffset
+    ));
+
+    if (typeof this.writable.close === 'function') {
+      await this.writable.close();
+    }
+    this.closed = true;
+  }
+
+  async abort() {
+    if (this.closed) return;
+    this.closed = true;
+    if (typeof this.writable.abort === 'function') {
+      await this.writable.abort();
+    }
+  }
+}

--- a/negative2positive/src/app/zipStoreWriter.test.mjs
+++ b/negative2positive/src/app/zipStoreWriter.test.mjs
@@ -1,0 +1,84 @@
+// Standalone Node test for zipStoreWriter.js - run with:
+// node negative2positive/src/app/zipStoreWriter.test.mjs
+
+import assert from 'node:assert/strict';
+import JSZip from 'jszip';
+import { ZipStoreWriter } from './zipStoreWriter.js';
+
+class MemoryWritable {
+  constructor() {
+    this.chunks = [];
+    this.closed = false;
+    this.aborted = false;
+  }
+
+  async write(chunk) {
+    assert.equal(this.closed, false, 'write after close');
+    assert.equal(this.aborted, false, 'write after abort');
+    if (chunk instanceof Uint8Array) {
+      this.chunks.push(new Uint8Array(chunk));
+      return;
+    }
+    if (chunk instanceof ArrayBuffer) {
+      this.chunks.push(new Uint8Array(chunk));
+      return;
+    }
+    if (ArrayBuffer.isView(chunk)) {
+      this.chunks.push(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+      return;
+    }
+    throw new Error('Unexpected chunk type');
+  }
+
+  async close() {
+    this.closed = true;
+  }
+
+  async abort() {
+    this.aborted = true;
+  }
+
+  bytes() {
+    const total = this.chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      out.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return out;
+  }
+}
+
+const writable = new MemoryWritable();
+const writer = new ZipStoreWriter(writable, { now: new Date('2026-05-16T00:00:00Z') });
+
+await writer.addBlob('alpha.txt', new Blob(['hello alpha']));
+await writer.addBlob('nested/beta.bin', new Blob([new Uint8Array([0, 1, 2, 3, 255])]));
+await writer.addBlob('../unsafe/gamma.txt', new Blob(['safe path']));
+await writer.close();
+
+assert.equal(writable.closed, true);
+assert.equal(writable.aborted, false);
+assert.ok(writable.chunks.length > 6, 'writer should stream multiple chunks');
+
+const archive = writable.bytes();
+const zip = await JSZip.loadAsync(archive, { checkCRC32: true });
+
+assert.deepEqual(Object.keys(zip.files).sort(), [
+  'alpha.txt',
+  'nested/beta.bin',
+  'unsafe/gamma.txt'
+]);
+assert.equal(await zip.file('alpha.txt').async('string'), 'hello alpha');
+assert.deepEqual(
+  Array.from(await zip.file('nested/beta.bin').async('uint8array')),
+  [0, 1, 2, 3, 255]
+);
+assert.equal(await zip.file('unsafe/gamma.txt').async('string'), 'safe path');
+
+for (const file of Object.values(zip.files)) {
+  assert.equal(file.dir, false);
+}
+
+console.log('zipStoreWriter.test.mjs passed');


### PR DESCRIPTION
## Root cause

Browser batch ZIP export queued every image Blob in JSZip and then generated one full archive Blob with DEFLATE. Large batches could therefore allocate a single huge archive buffer and crash with browser memory errors.

## Fix

- Added a STORE-only ZIP writer that streams one Blob at a time to the browser File System Access writable stream.
- Browser ZIP export now asks for the ZIP destination before processing, streams entries into the file, and reports partial failures without accumulating image blobs.
- Browsers without safe file streaming fall back to Download All Individually with a localized notice.
- Desktop/Tauri ZIP and directory export behavior is left on the existing split path.

## Verification

- node negative2positive/src/app/zipStoreWriter.test.mjs
- node negative2positive/src/silvercore/util/image16.test.mjs
- node negative2positive/src/silvercore/util/jpegSize.test.mjs
- node negative2positive/src/silvercore/util/garbledCheck.test.mjs
- npm run build:web
- cargo test --manifest-path src-tauri/Cargo.toml
- Chrome DevTools MCP QA: app loaded, streaming ZIP path called showSaveFilePicker before writing, produced a readable ZIP central directory with 32x32_converted.png, and no-stream fallback downloaded 32x32_converted.png individually instead of using ZIP generation.