### PR TITLE
Fix sprocket export photo preservation

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -9603,6 +9603,14 @@
       return null;
     }
 
+    async function renderCurrentImageDataForExport() {
+      await ensureFullResolutionReadyForExport();
+      ensureFullRender();
+      const imageData = await getCurrentExportImageData();
+      if (!imageData) throw new Error('No image available for export.');
+      return imageData;
+    }
+
     function notifyExportError(err) {
       console.error('Export failed:', err);
       const message = err && err.message ? err.message : String(err || 'Unknown error');
@@ -9621,21 +9629,20 @@
         overlay.updateProgress(5, lang.loadingAdjusting);
 
         const currentItem = getCurrentQueueItem();
-        if (currentItem && state.currentStep >= 3 && state.processedImageData) {
-          persistCurrentFileSettings({ silent: true });
-          const adjusted = await processFileWithSettings(currentItem.file, currentItem.settings);
-          const outputImageData = applySprocketFrameForExport(adjusted, exportInfo);
+        if (state.currentStep >= 3 && state.processedImageData) {
+          persistCurrentFileSettings({ silent: true, force: true });
+          const imageData = await renderCurrentImageDataForExport();
+          const outputImageData = applySprocketFrameForExport(imageData, exportInfo);
           overlay.updateProgress(60, lang.loadingEncoding);
           blob = await imageDataToBlob(outputImageData, exportInfo.format, state.jpegQuality, exportInfo.bitDepth, (pct) => {
             overlay.updateProgress(60 + pct * 0.35, lang.loadingEncoding);
           });
-          fileName = buildActiveExportFileName(currentItem.file.name, exportInfo);
+          if (currentItem?.file?.name) {
+            fileName = buildActiveExportFileName(currentItem.file.name, exportInfo);
+          }
         } else {
-          await ensureFullResolutionReadyForExport();
-          ensureFullRender();
           overlay.updateProgress(50, lang.loadingEncoding);
-          const imageData = await getCurrentExportImageData();
-          if (!imageData) throw new Error('No image available for export.');
+          const imageData = await renderCurrentImageDataForExport();
           const outputImageData = applySprocketFrameForExport(imageData, exportInfo);
           blob = await imageDataToBlob(outputImageData, exportInfo.format, state.jpegQuality, exportInfo.bitDepth, (pct) => {
             overlay.updateProgress(50 + pct * 0.45, lang.loadingEncoding);

--- a/negative2positive/src/app/sprocketFrame.js
+++ b/negative2positive/src/app/sprocketFrame.js
@@ -404,6 +404,15 @@ function fillFilmBase(data, metrics, filmColor) {
   }
 }
 
+function copyPhotoRegion(data, metrics, imageData) {
+  const src = imageData.data;
+  for (let y = 0; y < metrics.sourceHeight; y++) {
+    const srcOffset = y * metrics.sourceWidth * 4;
+    const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
+    data.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
+  }
+}
+
 function fillRect(data, metrics, left, top, width, height, fill, alpha = 1) {
   const rectLeft = Math.max(0, Math.round(left));
   const rectTop = Math.max(0, Math.round(top));
@@ -1142,19 +1151,14 @@ export function composeSprocketFrame(imageData, options = {}) {
 
   fillFilmBase(output, metrics, filmColor);
 
-  const src = imageData.data;
-  for (let y = 0; y < metrics.sourceHeight; y++) {
-    const srcOffset = y * metrics.sourceWidth * 4;
-    const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
-    output.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
-  }
-
   if (edge.overexposedSprockets) {
     paintSprocketTextureSmear(output, metrics, imageData, edge.overexposureStrength);
     paintOverexposedSprockets(output, metrics, edge.overexposureColor);
   }
   paintSprocketRows(output, metrics, holeColor);
   paintEdgeMarkings(output, metrics, edge);
+  // Hard guardrail: edge effects are allowed to touch only the added film border.
+  copyPhotoRegion(output, metrics, imageData);
 
   return new ImageData(output, metrics.outputWidth, metrics.outputHeight);
 }

--- a/negative2positive/src/app/sprocketFrame.test.mjs
+++ b/negative2positive/src/app/sprocketFrame.test.mjs
@@ -23,11 +23,27 @@ if (typeof globalThis.ImageData === 'undefined') {
 }
 
 const sourcePixels = new Uint8ClampedArray(10 * 6 * 4);
-for (let i = 0; i < sourcePixels.length; i += 4) {
-  sourcePixels[i] = 20;
-  sourcePixels[i + 1] = 80;
-  sourcePixels[i + 2] = 140;
-  sourcePixels[i + 3] = 255;
+for (let y = 0; y < 6; y++) {
+  for (let x = 0; x < 10; x++) {
+    const i = (y * 10 + x) * 4;
+    sourcePixels[i] = 20 + x * 7 + y * 3;
+    sourcePixels[i + 1] = 80 + x * 5 + y * 11;
+    sourcePixels[i + 2] = 140 + x * 4 + y * 3;
+    sourcePixels[i + 3] = 255;
+  }
+}
+
+function assertPhotoRegionMatchesSource(framedImageData, frameMetrics, sourceImageData) {
+  for (let y = 0; y < sourceImageData.height; y++) {
+    for (let x = 0; x < sourceImageData.width; x++) {
+      const srcIndex = (y * sourceImageData.width + x) * 4;
+      const dstIndex = ((y + frameMetrics.bandHeight) * framedImageData.width + frameMetrics.sideMargin + x) * 4;
+      assert.deepEqual(
+        Array.from(framedImageData.data.slice(dstIndex, dstIndex + 4)),
+        Array.from(sourceImageData.data.slice(srcIndex, srcIndex + 4))
+      );
+    }
+  }
 }
 
 const source = new ImageData(sourcePixels, 10, 6);
@@ -39,6 +55,7 @@ assert.equal(framed.height, metrics.outputHeight);
 
 const firstPhotoPixel = ((metrics.bandHeight * framed.width) + metrics.sideMargin) * 4;
 assert.deepEqual(Array.from(framed.data.slice(firstPhotoPixel, firstPhotoPixel + 4)), [20, 80, 140, 255]);
+assertPhotoRegionMatchesSource(framed, metrics, source);
 
 const filmPixel = 0;
 const filmPixelRgba = Array.from(framed.data.slice(filmPixel, filmPixel + 4));
@@ -91,16 +108,7 @@ const marked = composeSprocketFrame(source, markedOptions);
 assert.equal(marked.width, markedMetrics.outputWidth);
 assert.equal(marked.height, markedMetrics.outputHeight);
 assert.ok(marked.height > framed.height);
-for (let y = 0; y < source.height; y++) {
-  for (let x = 0; x < source.width; x++) {
-    const srcIndex = (y * source.width + x) * 4;
-    const dstIndex = ((y + markedMetrics.bandHeight) * marked.width + markedMetrics.sideMargin + x) * 4;
-    assert.deepEqual(
-      Array.from(marked.data.slice(dstIndex, dstIndex + 4)),
-      Array.from(source.data.slice(srcIndex, srcIndex + 4))
-    );
-  }
-}
+assertPhotoRegionMatchesSource(marked, markedMetrics, source);
 
 const assertEdgeLayoutDoesNotOverlapHoles = (layoutMetrics) => {
   const topTextBottom = layoutMetrics.topMarkingY + layoutMetrics.edgeTextHeight;


### PR DESCRIPTION
Summary:
- Export current images from the live full-resolution render path instead of re-reading the queue item.
- Re-copy the photo region after drawing sprocket effects so edge effects cannot alter it.
- Add pixel-level sprocket frame preservation coverage.

Validation:
- node negative2positive/src/app/sprocketFrame.test.mjs
- git diff --check
- npm run build:web