### PR TITLE
Fix preview render race and add analytics

### DIFF
--- a/negative2positive/35mm-film-border-sprocket-holes.html
+++ b/negative2positive/35mm-film-border-sprocket-holes.html
@@ -56,6 +56,7 @@
     ]
   }
   </script>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 <body>
   <header class="site-header">

--- a/negative2positive/batch-film-negative-converter.html
+++ b/negative2positive/batch-film-negative-converter.html
@@ -44,6 +44,7 @@
     ]
   }
   </script>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 <body>
   <header class="site-header">

--- a/negative2positive/download.html
+++ b/negative2positive/download.html
@@ -393,6 +393,7 @@
       }
     }
   </style>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 
 <body>

--- a/negative2positive/film-orange-mask.html
+++ b/negative2positive/film-orange-mask.html
@@ -56,6 +56,7 @@
     ]
   }
   </script>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 <body>
   <header class="site-header">

--- a/negative2positive/guide.html
+++ b/negative2positive/guide.html
@@ -27,6 +27,7 @@
   <meta name="twitter:image" content="https://negative-converter.tokugai.com/og-cover.png">
 
   <meta name="theme-color" content="#1a1a1a">
+  <script type="module" src="./src/app/analytics.js"></script>
 
   <script type="application/ld+json">
   {

--- a/negative2positive/index.html
+++ b/negative2positive/index.html
@@ -28,6 +28,7 @@
   <meta name="twitter:image" content="https://negative-converter.tokugai.com/og-cover.png">
 
   <meta name="theme-color" content="#1a1a1a">
+  <script type="module" src="./src/app/analytics.js"></script>
   <meta name="application-name" content="Negative Converter">
   <meta name="apple-mobile-web-app-title" content="Negative Converter">
 

--- a/negative2positive/iphone-proraw-negative-converter.html
+++ b/negative2positive/iphone-proraw-negative-converter.html
@@ -67,6 +67,7 @@
     ]
   }
   </script>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 <body>
   <header class="site-header">

--- a/negative2positive/negative-lab-pro-alternative.html
+++ b/negative2positive/negative-lab-pro-alternative.html
@@ -56,6 +56,7 @@
     ]
   }
   </script>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 <body>
   <header class="site-header">

--- a/negative2positive/privacy.html
+++ b/negative2positive/privacy.html
@@ -261,6 +261,7 @@
       }
     }
   </style>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 
 <body>

--- a/negative2positive/raw-negative-converter.html
+++ b/negative2positive/raw-negative-converter.html
@@ -65,6 +65,7 @@
     ]
   }
   </script>
+  <script type="module" src="./src/app/analytics.js"></script>
 </head>
 <body>
   <header class="site-header">

--- a/negative2positive/src/app/analytics.js
+++ b/negative2positive/src/app/analytics.js
@@ -1,0 +1,5 @@
+import { inject } from '@vercel/analytics';
+
+if (typeof window !== 'undefined' && !window.__TAURI__) {
+  inject();
+}

--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -5636,13 +5636,14 @@
 
       state.fullResolutionPending = true;
       const sourceRef = state.conversionSourceImageData;
+      const token = coreReprocessToken;
       const trace = createPerfTrace('fullResolutionRender', {
         reason,
         pixels: getImageDataPixelCount(state.conversionSourceImageData)
       });
 
       const promise = waitForNextFrame()
-        .then(() => rerenderWithCoreControls({ full: true, sourceRef }))
+        .then(() => rerenderWithCoreControls({ full: true, sourceRef, token }))
         .then(() => {
           trace.end({
             outputPixels: getImageDataPixelCount(state.processedImageData),
@@ -5685,6 +5686,15 @@
       scheduleFullResolutionRender('interactive-idle', FULL_RESOLUTION_IDLE_DELAY_MS);
     }
 
+    function cancelScheduledFullResolutionRender() {
+      if (!fullResolutionRenderTimer) return;
+      clearTimeout(fullResolutionRenderTimer);
+      fullResolutionRenderTimer = null;
+      if (!state.fullResolutionPromise) {
+        state.fullResolutionPending = Boolean(state.processedImageDataIsPreview);
+      }
+    }
+
     async function ensureFullResolutionReadyForExport() {
       if (!state.processedImageDataIsPreview && !state.fullResolutionPending) return;
       if (fullResolutionRenderTimer) {
@@ -5704,6 +5714,7 @@
       if (!state.conversionSourceImageData || state.currentStep < 3) return;
 
       const token = ++coreReprocessToken;
+      cancelScheduledFullResolutionRender();
       if (coreReprocessTimer) clearTimeout(coreReprocessTimer);
       coreReprocessTimer = setTimeout(() => {
         coreReprocessTimer = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@fontsource/inter": "5.2.8",
         "@neoanaloglabkk/lensfun-wasm": "0.1.3",
         "@techstark/opencv-js": "4.12.0-release.1",
+        "@vercel/analytics": "^2.0.1",
         "jszip": "3.10.1",
         "libraw-wasm": "^1.1.2",
         "pako": "2.1.0",
@@ -1007,6 +1008,48 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fontsource/inter": "5.2.8",
     "@neoanaloglabkk/lensfun-wasm": "0.1.3",
     "@techstark/opencv-js": "4.12.0-release.1",
+    "@vercel/analytics": "^2.0.1",
     "jszip": "3.10.1",
     "libraw-wasm": "^1.1.2",
     "pako": "2.1.0",


### PR DESCRIPTION
## Summary

- Prevent stale full-resolution SilverCore renders from briefly overwriting the active preview while dragging core adjustment controls.
- Add Vercel Analytics through a Vite/static-compatible analytics entrypoint and load it from each static HTML page.
- Guard analytics injection in Tauri so the desktop app does not load the Vercel script.

## Root Cause

The red flash during brightness/exposure-style adjustments came from a preview/full-resolution render race. A previously scheduled full-resolution render could finish after the user had already changed controls, briefly applying stale pixel output before the newer preview render restored the expected image.

## Validation

- `node negative2positive/src/app/sprocketFrame.test.mjs`
- `git diff --check`
- `npm run build:web`
- Browser smoke check for `/` and `/guide.html`
