### PR TITLE
Optimize sprocket preview adjustments

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -23,6 +23,7 @@
     import {
       DEFAULT_SPROCKET_EDGE_MARKINGS,
       composeSprocketFrame,
+      composeSprocketFrameBackground,
       getSprocketFrameMetrics,
       normalizeSprocketEdgeMarkings
     } from './sprocketFrame.js';
@@ -3362,6 +3363,13 @@
     const beforeAfterScratchCtx = beforeAfterScratchCanvas.getContext('2d', { willReadFrequently: true });
     const sprocketScratchCanvas = document.createElement('canvas');
     const sprocketScratchCtx = sprocketScratchCanvas.getContext('2d', { willReadFrequently: true });
+    const sprocketPreviewFrameCanvas = document.createElement('canvas');
+    const sprocketPreviewFrameCtx = sprocketPreviewFrameCanvas.getContext('2d');
+    const sprocketPreviewFrameCache = {
+      key: '',
+      sourceRef: null,
+      metrics: null
+    };
 
     let transformCanvas = document.createElement('canvas');
     let transformCtx = transformCanvas.getContext('2d');
@@ -3878,9 +3886,73 @@
       ctx.drawImage(sprocketScratchCanvas, 0, 0, targetWidth, targetHeight);
     }
 
-    function renderAdjustedImageDataToMainCanvas(imageData, fullSizeReference = imageData) {
+    function getSprocketPreviewFrameCacheKey(imageData, fullSizeReference, composeOptions) {
+      return JSON.stringify({
+        sourceWidth: imageData.width,
+        sourceHeight: imageData.height,
+        targetWidth: fullSizeReference.width,
+        targetHeight: fullSizeReference.height,
+        edgeMarkings: composeOptions.edgeMarkings
+      });
+    }
+
+    function ensureSprocketPreviewFrameBackground(imageData, fullSizeReference, composeOptions) {
+      if (!sprocketPreviewFrameCtx) return null;
+      const key = getSprocketPreviewFrameCacheKey(imageData, fullSizeReference, composeOptions);
+      if (
+        sprocketPreviewFrameCache.key === key
+        && sprocketPreviewFrameCache.sourceRef === fullSizeReference
+        && sprocketPreviewFrameCache.metrics
+        && sprocketPreviewFrameCanvas.width > 0
+        && sprocketPreviewFrameCanvas.height > 0
+      ) {
+        return sprocketPreviewFrameCache;
+      }
+
+      const background = composeSprocketFrameBackground(imageData, composeOptions);
+      if (sprocketPreviewFrameCanvas.width !== background.width) sprocketPreviewFrameCanvas.width = background.width;
+      if (sprocketPreviewFrameCanvas.height !== background.height) sprocketPreviewFrameCanvas.height = background.height;
+      sprocketPreviewFrameCtx.clearRect(0, 0, background.width, background.height);
+      sprocketPreviewFrameCtx.putImageData(background, 0, 0);
+
+      sprocketPreviewFrameCache.key = key;
+      sprocketPreviewFrameCache.sourceRef = fullSizeReference;
+      sprocketPreviewFrameCache.metrics = getSprocketFrameMetrics(imageData.width, imageData.height, composeOptions);
+      return sprocketPreviewFrameCache;
+    }
+
+    function renderFastSprocketPreview(imageData, fullSizeReference, composeOptions) {
+      const targetMetrics = getSprocketFrameMetrics(fullSizeReference.width, fullSizeReference.height, composeOptions);
+      const frameCache = ensureSprocketPreviewFrameBackground(imageData, fullSizeReference, composeOptions);
+      if (!frameCache) return false;
+      const frameMetrics = frameCache.metrics;
+      setMainCanvasDimensions(targetMetrics.outputWidth, targetMetrics.outputHeight);
+      ctx.clearRect(0, 0, targetMetrics.outputWidth, targetMetrics.outputHeight);
+      ctx.imageSmoothingEnabled = true;
+      ctx.drawImage(sprocketPreviewFrameCanvas, 0, 0, targetMetrics.outputWidth, targetMetrics.outputHeight);
+
+      if (sprocketScratchCanvas.width !== imageData.width) sprocketScratchCanvas.width = imageData.width;
+      if (sprocketScratchCanvas.height !== imageData.height) sprocketScratchCanvas.height = imageData.height;
+      sprocketScratchCtx.putImageData(imageData, 0, 0);
+
+      const scaleX = targetMetrics.outputWidth / frameMetrics.outputWidth;
+      const scaleY = targetMetrics.outputHeight / frameMetrics.outputHeight;
+      ctx.drawImage(
+        sprocketScratchCanvas,
+        frameMetrics.sideMargin * scaleX,
+        frameMetrics.bandHeight * scaleY,
+        frameMetrics.sourceWidth * scaleX,
+        frameMetrics.sourceHeight * scaleY
+      );
+      return true;
+    }
+
+    function renderAdjustedImageDataToMainCanvas(imageData, fullSizeReference = imageData, options = {}) {
       if (state.sprocketPreviewEnabled && !state.cropping) {
         const composeOptions = getSprocketFrameComposeOptions();
+        if (options.fastSprocketPreview && renderFastSprocketPreview(imageData, fullSizeReference, composeOptions)) {
+          return;
+        }
         const frameMetrics = getSprocketFrameMetrics(fullSizeReference.width, fullSizeReference.height, composeOptions);
         const framed = composeSprocketFrame(imageData, composeOptions);
         setMainCanvasDimensions(frameMetrics.outputWidth, frameMetrics.outputHeight);
@@ -5290,10 +5362,14 @@
       applyAdjustmentsToBuffer(source, state, previewAdjustedBuffer, 'preview');
 
       if (source !== state.processedImageData) {
-        renderAdjustedImageDataToMainCanvas(previewAdjustedBuffer, state.processedImageData);
+        renderAdjustedImageDataToMainCanvas(previewAdjustedBuffer, state.processedImageData, {
+          fastSprocketPreview: true
+        });
         state.lastRenderQuality = 'preview';
       } else {
-        renderAdjustedImageDataToMainCanvas(previewAdjustedBuffer, source);
+        renderAdjustedImageDataToMainCanvas(previewAdjustedBuffer, source, {
+          fastSprocketPreview: true
+        });
         state.displayImageData = previewAdjustedBuffer;
         state.lastRenderQuality = 'full';
       }

--- a/negative2positive/src/app/sprocketFrame.js
+++ b/negative2positive/src/app/sprocketFrame.js
@@ -413,6 +413,13 @@ function copyPhotoRegion(data, metrics, imageData) {
   }
 }
 
+function clearPhotoRegion(data, metrics) {
+  for (let y = 0; y < metrics.sourceHeight; y++) {
+    const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
+    data.fill(0, dstOffset, dstOffset + metrics.sourceWidth * 4);
+  }
+}
+
 function fillRect(data, metrics, left, top, width, height, fill, alpha = 1) {
   const rectLeft = Math.max(0, Math.round(left));
   const rectTop = Math.max(0, Math.round(top));
@@ -1135,7 +1142,7 @@ function paintEdgeMarkings(data, metrics, edge) {
   if (edge.frameNumberEnabled) paintFrameNumberMarker(data, metrics, edge);
 }
 
-export function composeSprocketFrame(imageData, options = {}) {
+function createSprocketFrameImageData(imageData, options = {}, { includePhoto = true } = {}) {
   if (!imageData || !imageData.data || !imageData.width || !imageData.height) {
     throw new Error('ImageData is required to compose sprocket holes.');
   }
@@ -1157,10 +1164,22 @@ export function composeSprocketFrame(imageData, options = {}) {
   }
   paintSprocketRows(output, metrics, holeColor);
   paintEdgeMarkings(output, metrics, edge);
-  // Hard guardrail: edge effects are allowed to touch only the added film border.
-  copyPhotoRegion(output, metrics, imageData);
+  if (includePhoto) {
+    // Hard guardrail: edge effects are allowed to touch only the added film border.
+    copyPhotoRegion(output, metrics, imageData);
+  } else {
+    clearPhotoRegion(output, metrics);
+  }
 
   return new ImageData(output, metrics.outputWidth, metrics.outputHeight);
+}
+
+export function composeSprocketFrame(imageData, options = {}) {
+  return createSprocketFrameImageData(imageData, options, { includePhoto: true });
+}
+
+export function composeSprocketFrameBackground(imageData, options = {}) {
+  return createSprocketFrameImageData(imageData, options, { includePhoto: false });
 }
 
 export function hasSprocketFrameEnabled(settings) {

--- a/negative2positive/src/app/sprocketFrame.test.mjs
+++ b/negative2positive/src/app/sprocketFrame.test.mjs
@@ -7,6 +7,7 @@ import {
   THIRTY_FIVE_MM_SPROCKET_SPEC,
   buildDxEdgeCodeBlocks,
   composeSprocketFrame,
+  composeSprocketFrameBackground,
   getSprocketFrameMetrics,
   hasSprocketFrameEnabled,
   normalizeSprocketEdgeMarkings
@@ -56,6 +57,12 @@ assert.equal(framed.height, metrics.outputHeight);
 const firstPhotoPixel = ((metrics.bandHeight * framed.width) + metrics.sideMargin) * 4;
 assert.deepEqual(Array.from(framed.data.slice(firstPhotoPixel, firstPhotoPixel + 4)), [20, 80, 140, 255]);
 assertPhotoRegionMatchesSource(framed, metrics, source);
+
+const frameBackground = composeSprocketFrameBackground(source);
+assert.equal(frameBackground.width, metrics.outputWidth);
+assert.equal(frameBackground.height, metrics.outputHeight);
+assert.deepEqual(Array.from(frameBackground.data.slice(firstPhotoPixel, firstPhotoPixel + 4)), [0, 0, 0, 0]);
+assert.notDeepEqual(Array.from(frameBackground.data.slice(0, 4)), [0, 0, 0, 0]);
 
 const filmPixel = 0;
 const filmPixelRgba = Array.from(framed.data.slice(filmPixel, filmPixel + 4));


### PR DESCRIPTION
## Summary
- cache the sprocket preview frame background during interactive adjustments
- keep full-resolution composition for idle/full render and export
- add coverage for transparent preview frame backgrounds

## Tests
- git diff --check
- node negative2positive/src/app/sprocketFrame.test.mjs
- npm run build:web