### PR TITLE
fix: use forked libraw-wasm + JPEG fallback for unsupported RAW

### DIFF
--- a/negative2positive/src/app/rawFileLoader.js
+++ b/negative2positive/src/app/rawFileLoader.js
@@ -237,6 +237,10 @@ export async function loadRawFile(buffer, fileName, options = {}) {
     }
     throw err;
   }
+  if (!result || !result.data) {
+    console.error('[RAW] imageData returned empty result', result);
+    return await handleTimeoutFallback();
+  }
   const { width, height, data: rgbData } = result;
 
   const pixelCount = width * height;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@techstark/opencv-js": "4.12.0-release.1",
         "@vercel/analytics": "^2.0.1",
         "jszip": "3.10.1",
-        "libraw-wasm": "^1.1.2",
+        "libraw-wasm": "github:lexluthor0304/LibRaw-Wasm",
         "pako": "2.1.0",
         "three": "^0.183.2",
         "upng-js": "2.1.0",
@@ -1533,9 +1533,8 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/libraw-wasm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/libraw-wasm/-/libraw-wasm-1.1.2.tgz",
-      "integrity": "sha512-lOVdqbzCkvsLtMoTz41Pc3alQptWHCyD71jGBTnQmoNK5CTVayXGqtTSBntLil7YaO3h/yESx7e9jMskMtnOEQ==",
+      "version": "1.2.0",
+      "resolved": "git+ssh://git@github.com/lexluthor0304/LibRaw-Wasm.git#c17e6ffa83f176497f07a90e740fca495ce0eca3",
       "license": "ISC"
     },
     "node_modules/lie": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@techstark/opencv-js": "4.12.0-release.1",
     "@vercel/analytics": "^2.0.1",
     "jszip": "3.10.1",
-    "libraw-wasm": "^1.1.2",
+    "libraw-wasm": "github:lexluthor0304/LibRaw-Wasm",
     "pako": "2.1.0",
     "three": "^0.183.2",
     "upng-js": "2.1.0",


### PR DESCRIPTION
## Summary

Use a forked build of `libraw-wasm` (rebased on LibRaw 0.22.1) to add support for newer cameras including Nikon Z f, Z8, Z6-III, while adding a defensive JPEG preview fallback for any RAW files that LibRaw cannot fully decode.

## Problem

The npm package `libraw-wasm@1.1.2` bundles a WASM binary from an older LibRaw that does not recognize cameras released after ~2022. Nikon Z f NEF files fail with a generic "Error loading file."

## Changes

### 1. Switch to forked libraw-wasm
- **`package.json`**: `libraw-wasm` → `github:lexluthor0304/LibRaw-Wasm`
- Rebuilt with LibRaw 0.22.1 (pinned), adding support for Z f, Z8, Z6-III, Z30, plus Canon R1/R5 II, Sony A9-III, Fuji X-T50, and many more

### 2. Defensive JPEG preview fallback
- **`rawFileLoader.js`**: When `raw.imageData()` returns empty (e.g. `dcraw_make_mem_image()` NULL), fall back to the embedded camera-rendered JPEG preview instead of showing a generic error
- Same 6048×4032 resolution, 8-bit precision (vs 16-bit from LibRaw)

## How to switch back

When the upstream PR (https://github.com/ybouane/LibRaw-Wasm/pull/15) is merged and published:
```bash
npm install libraw-wasm@latest
```
Revert the package.json change.

## Test plan
- [x] Nikon Z f NEF loads via JPEG fallback (6048×4032, 8-bit)
- [x] Sony ARW decodes correctly via LibRaw (16-bit)
- [x] No regression for standard image formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)