### PR TITLE
fix: portrait (2:3) sprocket orientation + rotation crop preservation

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -3937,10 +3937,15 @@
 
       const scaleX = targetMetrics.outputWidth / frameMetrics.outputWidth;
       const scaleY = targetMetrics.outputHeight / frameMetrics.outputHeight;
+      const photoX = frameMetrics.isPortrait
+        ? frameMetrics.bandHeight * scaleX
+        : frameMetrics.sideMargin * scaleX;
+      const photoY = frameMetrics.isPortrait
+        ? frameMetrics.sideMargin * scaleY
+        : frameMetrics.bandHeight * scaleY;
       ctx.drawImage(
         sprocketScratchCanvas,
-        frameMetrics.sideMargin * scaleX,
-        frameMetrics.bandHeight * scaleY,
+        photoX, photoY,
         frameMetrics.sourceWidth * scaleX,
         frameMetrics.sourceHeight * scaleY
       );

--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -3937,15 +3937,10 @@
 
       const scaleX = targetMetrics.outputWidth / frameMetrics.outputWidth;
       const scaleY = targetMetrics.outputHeight / frameMetrics.outputHeight;
-      const photoX = frameMetrics.isPortrait
-        ? frameMetrics.bandHeight * scaleX
-        : frameMetrics.sideMargin * scaleX;
-      const photoY = frameMetrics.isPortrait
-        ? frameMetrics.sideMargin * scaleY
-        : frameMetrics.bandHeight * scaleY;
       ctx.drawImage(
         sprocketScratchCanvas,
-        photoX, photoY,
+        frameMetrics.sideMargin * scaleX,
+        frameMetrics.bandHeight * scaleY,
         frameMetrics.sourceWidth * scaleX,
         frameMetrics.sourceHeight * scaleY
       );
@@ -7987,7 +7982,7 @@
       pushUndo('rotation');
       const sourceOriginal = state.originalImageData;
       const sourceCrop = state.cropRegion ? { ...state.cropRegion } : null;
-      const shouldPreserveCrop = state.currentStep >= 3 && Boolean(sourceCrop);
+      const shouldPreserveCrop = Boolean(sourceCrop);
 
       const rotatedData = applyRotationToImageData(sourceOriginal, normalizedAngle);
       if (!rotatedData) return;

--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -3922,6 +3922,10 @@
     }
 
     function renderFastSprocketPreview(imageData, fullSizeReference, composeOptions) {
+      // Portrait images go through the full compose path (composeSprocketFrame
+      // handles pre/post rotation internally).
+      if (imageData.height > imageData.width) return false;
+
       const targetMetrics = getSprocketFrameMetrics(fullSizeReference.width, fullSizeReference.height, composeOptions);
       const frameCache = ensureSprocketPreviewFrameBackground(imageData, fullSizeReference, composeOptions);
       if (!frameCache) return false;

--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -3957,10 +3957,9 @@
         if (options.fastSprocketPreview && renderFastSprocketPreview(imageData, fullSizeReference, composeOptions)) {
           return;
         }
-        const frameMetrics = getSprocketFrameMetrics(fullSizeReference.width, fullSizeReference.height, composeOptions);
         const framed = composeSprocketFrame(imageData, composeOptions);
-        setMainCanvasDimensions(frameMetrics.outputWidth, frameMetrics.outputHeight);
-        drawImageDataToMainCanvas(framed, frameMetrics.outputWidth, frameMetrics.outputHeight);
+        setMainCanvasDimensions(framed.width, framed.height);
+        drawImageDataToMainCanvas(framed, framed.width, framed.height);
         return;
       }
 

--- a/negative2positive/src/app/sprocketFrame.js
+++ b/negative2positive/src/app/sprocketFrame.js
@@ -165,12 +165,18 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
   const edge = getComposeEdgeMarkings(options);
   const sourceWidth = Math.max(1, Math.round(Number(width) || 1));
   const sourceHeight = Math.max(1, Math.round(Number(height) || 1));
+  const isPortrait = sourceHeight > sourceWidth;
   const shortSide = Math.min(sourceWidth, sourceHeight);
   const showMarkings = hasVisibleEdgeMarkings(edge);
   const spec = THIRTY_FIVE_MM_SPROCKET_SPEC;
-  const imagePxPerMmX = sourceWidth / spec.stillFrameWidthMm;
+
+  // For portrait (2:3), the sprocket bands go on left/right instead of top/bottom.
+  // Internally swap width↔height so the existing calculations work correctly.
+  const sx = isPortrait ? sourceHeight : sourceWidth;
+  const sy = isPortrait ? sourceWidth : sourceHeight;
+  const imagePxPerMmX = sx / spec.stillFrameWidthMm;
   const filmEdgeBandMm = (spec.filmWidthMm - spec.stillFrameHeightMm) / 2;
-  const physicalBandHeight = Math.round(sourceHeight * filmEdgeBandMm / spec.stillFrameHeightMm);
+  const physicalBandHeight = Math.round(sy * filmEdgeBandMm / spec.stillFrameHeightMm);
   const sideMargin = clamp(
     Math.round(imagePxPerMmX * 1.0),
     8,
@@ -180,7 +186,7 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
   const bandHeight = clamp(
     physicalBandHeight,
     bandMin,
-    Math.max(bandMin, Math.round(sourceHeight * 0.36))
+    Math.max(bandMin, Math.round(sy * 0.36))
   );
   const filmEdgePxPerMmY = bandHeight / filmEdgeBandMm;
   const mm = Math.max(1, (imagePxPerMmX + filmEdgePxPerMmY) / 2);
@@ -192,8 +198,8 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
     Math.max(10, bandHeight - edgeGap * 2)
   );
   const holeRadius = Math.max(2, Math.round(holeHeight * 0.18));
-  const outputWidth = sourceWidth + sideMargin * 2;
-  const outputHeight = sourceHeight + bandHeight * 2;
+  const outputWidth = isPortrait ? sourceWidth + bandHeight * 2 : sourceWidth + sideMargin * 2;
+  const outputHeight = isPortrait ? sourceHeight + sideMargin * 2 : sourceHeight + bandHeight * 2;
   const edgeTextPixelSize = Math.max(7, Math.round(filmEdgePxPerMmY * 1.12));
   const edgeTextHeight = Math.max(1, Math.ceil(edgeTextPixelSize * 1.35));
   const pitch = Math.max(holeWidth + edgeGap * 2, Math.round(spec.perforationPitchMm * imagePxPerMmX));
@@ -240,6 +246,12 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
     )
     : 0;
 
+  // For portrait, swap X/Y semantics: holes go on left/right instead of top/bottom.
+  const leftX = isPortrait ? outerPerfMargin : topY;
+  const rightX = isPortrait ? (bandHeight + sourceWidth + bandHeight - outerPerfMargin - holeHeight) : topY;
+  const leftMarkingY = isPortrait ? topMarkingY : 0;
+  const rightMarkingY = isPortrait ? bottomMarkingY : 0;
+
   return {
     sourceWidth,
     sourceHeight,
@@ -257,12 +269,21 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
     firstHoleIndex,
     frameStartX,
     startX,
+    // Landscape: sprocket bands are top/bottom
     topY,
     bottomY,
     topMarkingY,
     topTextY,
     bottomMarkingY,
     bottomDxY,
+    // Portrait: sprocket bands are left/right
+    isPortrait,
+    leftX,
+    rightX,
+    leftMarkingY,
+    rightMarkingY,
+    leftBandWidth: bandHeight,    // same value, renamed for clarity
+    rightBandStart: sourceWidth + bandHeight,
     edgeTextPixelSize,
     edgeTextHeight,
     dxCodeHeight,
@@ -394,29 +415,58 @@ function fillFilmBase(data, metrics, filmColor) {
     }
   };
 
-  paintSpan(0, 0, metrics.outputWidth, metrics.bandHeight);
-  paintSpan(0, metrics.bottomBandTop, metrics.outputWidth, metrics.outputHeight - metrics.bottomBandTop);
-  if (metrics.sideMargin > 0) {
-    const middleTop = metrics.bandHeight;
-    const middleHeight = metrics.sourceHeight;
-    paintSpan(0, middleTop, metrics.sideMargin, middleHeight);
-    paintSpan(metrics.sideMargin + metrics.sourceWidth, middleTop, metrics.sideMargin, middleHeight);
+  if (metrics.isPortrait) {
+    // Bands on left and right sides
+    paintSpan(0, 0, metrics.bandHeight, metrics.outputHeight);
+    paintSpan(metrics.rightBandStart, 0, metrics.outputWidth - metrics.rightBandStart, metrics.outputHeight);
+    if (metrics.sideMargin > 0) {
+      paintSpan(metrics.bandHeight, 0, metrics.sourceWidth, metrics.sideMargin);
+      paintSpan(metrics.bandHeight, metrics.sideMargin + metrics.sourceHeight, metrics.sourceWidth, metrics.sideMargin);
+    }
+  } else {
+    paintSpan(0, 0, metrics.outputWidth, metrics.bandHeight);
+    paintSpan(0, metrics.bottomBandTop, metrics.outputWidth, metrics.outputHeight - metrics.bottomBandTop);
+    if (metrics.sideMargin > 0) {
+      const middleTop = metrics.bandHeight;
+      const middleHeight = metrics.sourceHeight;
+      paintSpan(0, middleTop, metrics.sideMargin, middleHeight);
+      paintSpan(metrics.sideMargin + metrics.sourceWidth, middleTop, metrics.sideMargin, middleHeight);
+    }
   }
 }
 
 function copyPhotoRegion(data, metrics, imageData) {
   const src = imageData.data;
-  for (let y = 0; y < metrics.sourceHeight; y++) {
-    const srcOffset = y * metrics.sourceWidth * 4;
-    const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
-    data.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
+  if (metrics.isPortrait) {
+    for (let y = 0; y < metrics.sourceHeight; y++) {
+      const srcOffset = y * metrics.sourceWidth * 4;
+      const dstX = metrics.bandHeight;
+      const dstY = y + metrics.sideMargin;
+      const dstOffset = (dstY * metrics.outputWidth + dstX) * 4;
+      data.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
+    }
+  } else {
+    for (let y = 0; y < metrics.sourceHeight; y++) {
+      const srcOffset = y * metrics.sourceWidth * 4;
+      const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
+      data.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
+    }
   }
 }
 
 function clearPhotoRegion(data, metrics) {
-  for (let y = 0; y < metrics.sourceHeight; y++) {
-    const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
-    data.fill(0, dstOffset, dstOffset + metrics.sourceWidth * 4);
+  if (metrics.isPortrait) {
+    for (let y = 0; y < metrics.sourceHeight; y++) {
+      const dstX = metrics.bandHeight;
+      const dstY = y + metrics.sideMargin;
+      const dstOffset = (dstY * metrics.outputWidth + dstX) * 4;
+      data.fill(0, dstOffset, dstOffset + metrics.sourceWidth * 4);
+    }
+  } else {
+    for (let y = 0; y < metrics.sourceHeight; y++) {
+      const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
+      data.fill(0, dstOffset, dstOffset + metrics.sourceWidth * 4);
+    }
   }
 }
 
@@ -485,11 +535,22 @@ function paintSprocketHole(data, metrics, left, top, fill) {
 }
 
 function forEachSprocketHole(metrics, callback) {
-  for (let i = 0; i < metrics.holeCount; i++) {
-    const holeIndex = (metrics.firstHoleIndex || 0) + i;
-    const left = (metrics.frameStartX ?? metrics.startX) + holeIndex * metrics.pitch;
-    callback(left, metrics.topY, holeIndex);
-    callback(left, metrics.bottomY, holeIndex);
+  if (metrics.isPortrait) {
+    // Portrait: holes are on left and right sides, running vertically
+    for (let i = 0; i < metrics.holeCount; i++) {
+      const holeIndex = (metrics.firstHoleIndex || 0) + i;
+      const top = (metrics.frameStartX ?? metrics.startX) + holeIndex * metrics.pitch;
+      callback(metrics.leftX, top, holeIndex);
+      callback(metrics.rightX, top, holeIndex);
+    }
+  } else {
+    // Landscape: holes on top and bottom
+    for (let i = 0; i < metrics.holeCount; i++) {
+      const holeIndex = (metrics.firstHoleIndex || 0) + i;
+      const left = (metrics.frameStartX ?? metrics.startX) + holeIndex * metrics.pitch;
+      callback(left, metrics.topY, holeIndex);
+      callback(left, metrics.bottomY, holeIndex);
+    }
   }
 }
 
@@ -503,8 +564,13 @@ function roundedRectDistance(px, py, left, top, width, height, radius) {
   return outside + inside - radius;
 }
 
-function getSprocketBandClip(metrics, top) {
-  return top < metrics.bandHeight
+function getSprocketBandClip(metrics, offset) {
+  if (metrics.isPortrait) {
+    return offset < metrics.bandHeight
+      ? { left: 0, right: metrics.bandHeight }
+      : { left: metrics.rightBandStart, right: metrics.outputWidth };
+  }
+  return offset < metrics.bandHeight
     ? { top: 0, bottom: metrics.bandHeight }
     : { top: metrics.bottomBandTop, bottom: metrics.outputHeight };
 }
@@ -514,28 +580,31 @@ function paintSprocketGlow(data, metrics, left, top, fill, strength = 1) {
   if (amount <= 0) return;
   const spread = Math.max(4, Math.round(metrics.holeHeight * (0.42 + amount * 0.38)));
   const bandClip = getSprocketBandClip(metrics, top);
-  const rectLeft = Math.max(0, Math.round(left - spread));
-  const rectTop = Math.max(bandClip.top, Math.round(top - spread));
-  const rectRight = Math.min(metrics.outputWidth, Math.round(left + metrics.holeWidth + spread));
-  const rectBottom = Math.min(bandClip.bottom, Math.round(top + metrics.holeHeight + spread));
+  const isPortrait = metrics.isPortrait;
+
+  const rectLeft = Math.max(isPortrait ? (bandClip.left || 0) : 0, Math.round(left - spread));
+  const rectTop = Math.max(isPortrait ? 0 : (bandClip.top || 0), Math.round(top - spread));
+  const rectRight = Math.min(
+    isPortrait ? (bandClip.right || metrics.outputWidth) : metrics.outputWidth,
+    Math.round(left + metrics.holeWidth + spread)
+  );
+  const rectBottom = Math.min(
+    isPortrait ? metrics.outputHeight : (bandClip.bottom || metrics.outputHeight),
+    Math.round(top + metrics.holeHeight + spread)
+  );
 
   for (let y = rectTop; y < rectBottom; y++) {
     for (let x = rectLeft; x < rectRight; x++) {
       const distance = roundedRectDistance(
-        x + 0.5,
-        y + 0.5,
-        left,
-        top,
-        metrics.holeWidth,
-        metrics.holeHeight,
-        metrics.holeRadius
+        x + 0.5, y + 0.5,
+        left, top, metrics.holeWidth, metrics.holeHeight, metrics.holeRadius
       );
       if (distance < 0 || distance > spread) continue;
       const falloff = 1 - distance / spread;
-      const isTopRow = top < metrics.bandHeight;
-      const inward = isTopRow
-        ? clamp((y - top) / Math.max(1, metrics.holeHeight + spread), 0, 1)
-        : clamp((top + metrics.holeHeight - y) / Math.max(1, metrics.holeHeight + spread), 0, 1);
+      const isNear = isPortrait ? (left < metrics.bandHeight) : (top < metrics.bandHeight);
+      const inward = isNear
+        ? clamp(isPortrait ? ((x - left) / Math.max(1, metrics.holeWidth + spread)) : ((y - top) / Math.max(1, metrics.holeHeight + spread)), 0, 1)
+        : clamp(isPortrait ? ((left + metrics.holeWidth - x) / Math.max(1, metrics.holeWidth + spread)) : ((top + metrics.holeHeight - y) / Math.max(1, metrics.holeHeight + spread)), 0, 1);
       const localScale = Math.max(4, Math.round(metrics.holeHeight * 0.42));
       const coarse = smoothNoise(x - left, y - top, localScale, 914);
       const fine = hashNoise((x - left) * 1.7, (y - top) * 1.3, 915);

--- a/negative2positive/src/app/sprocketFrame.js
+++ b/negative2positive/src/app/sprocketFrame.js
@@ -165,15 +165,13 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
   const edge = getComposeEdgeMarkings(options);
   const sourceWidth = Math.max(1, Math.round(Number(width) || 1));
   const sourceHeight = Math.max(1, Math.round(Number(height) || 1));
-  const isPortrait = sourceHeight > sourceWidth;
   const shortSide = Math.min(sourceWidth, sourceHeight);
   const showMarkings = hasVisibleEdgeMarkings(edge);
   const spec = THIRTY_FIVE_MM_SPROCKET_SPEC;
 
-  // For portrait (2:3), the sprocket bands go on left/right instead of top/bottom.
-  // Internally swap width↔height so the existing calculations work correctly.
-  const sx = isPortrait ? sourceHeight : sourceWidth;
-  const sy = isPortrait ? sourceWidth : sourceHeight;
+  // Input is always landscape at this point (portrait images are pre-rotated by the caller).
+  const sx = sourceWidth;
+  const sy = sourceHeight;
   const imagePxPerMmX = sx / spec.stillFrameWidthMm;
   const filmEdgeBandMm = (spec.filmWidthMm - spec.stillFrameHeightMm) / 2;
   const physicalBandHeight = Math.round(sy * filmEdgeBandMm / spec.stillFrameHeightMm);
@@ -198,8 +196,8 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
     Math.max(10, bandHeight - edgeGap * 2)
   );
   const holeRadius = Math.max(2, Math.round(holeHeight * 0.18));
-  const outputWidth = isPortrait ? sourceWidth + bandHeight * 2 : sourceWidth + sideMargin * 2;
-  const outputHeight = isPortrait ? sourceHeight + sideMargin * 2 : sourceHeight + bandHeight * 2;
+  const outputWidth = sourceWidth + sideMargin * 2;
+  const outputHeight = sourceHeight + bandHeight * 2;
   const edgeTextPixelSize = Math.max(7, Math.round(filmEdgePxPerMmY * 1.12));
   const edgeTextHeight = Math.max(1, Math.ceil(edgeTextPixelSize * 1.35));
   const pitch = Math.max(holeWidth + edgeGap * 2, Math.round(spec.perforationPitchMm * imagePxPerMmX));
@@ -246,12 +244,6 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
     )
     : 0;
 
-  // For portrait, swap X/Y semantics: holes go on left/right instead of top/bottom.
-  const leftX = isPortrait ? outerPerfMargin : topY;
-  const rightX = isPortrait ? (bandHeight + sourceWidth + bandHeight - outerPerfMargin - holeHeight) : topY;
-  const leftMarkingY = isPortrait ? topMarkingY : 0;
-  const rightMarkingY = isPortrait ? bottomMarkingY : 0;
-
   return {
     sourceWidth,
     sourceHeight,
@@ -269,21 +261,12 @@ export function getSprocketFrameMetrics(width, height, options = {}) {
     firstHoleIndex,
     frameStartX,
     startX,
-    // Landscape: sprocket bands are top/bottom
     topY,
     bottomY,
     topMarkingY,
     topTextY,
     bottomMarkingY,
     bottomDxY,
-    // Portrait: sprocket bands are left/right
-    isPortrait,
-    leftX,
-    rightX,
-    leftMarkingY,
-    rightMarkingY,
-    leftBandWidth: bandHeight,    // same value, renamed for clarity
-    rightBandStart: sourceWidth + bandHeight,
     edgeTextPixelSize,
     edgeTextHeight,
     dxCodeHeight,
@@ -415,58 +398,29 @@ function fillFilmBase(data, metrics, filmColor) {
     }
   };
 
-  if (metrics.isPortrait) {
-    // Bands on left and right sides
-    paintSpan(0, 0, metrics.bandHeight, metrics.outputHeight);
-    paintSpan(metrics.rightBandStart, 0, metrics.outputWidth - metrics.rightBandStart, metrics.outputHeight);
-    if (metrics.sideMargin > 0) {
-      paintSpan(metrics.bandHeight, 0, metrics.sourceWidth, metrics.sideMargin);
-      paintSpan(metrics.bandHeight, metrics.sideMargin + metrics.sourceHeight, metrics.sourceWidth, metrics.sideMargin);
-    }
-  } else {
-    paintSpan(0, 0, metrics.outputWidth, metrics.bandHeight);
-    paintSpan(0, metrics.bottomBandTop, metrics.outputWidth, metrics.outputHeight - metrics.bottomBandTop);
-    if (metrics.sideMargin > 0) {
-      const middleTop = metrics.bandHeight;
-      const middleHeight = metrics.sourceHeight;
-      paintSpan(0, middleTop, metrics.sideMargin, middleHeight);
-      paintSpan(metrics.sideMargin + metrics.sourceWidth, middleTop, metrics.sideMargin, middleHeight);
-    }
+  paintSpan(0, 0, metrics.outputWidth, metrics.bandHeight);
+  paintSpan(0, metrics.bottomBandTop, metrics.outputWidth, metrics.outputHeight - metrics.bottomBandTop);
+  if (metrics.sideMargin > 0) {
+    const middleTop = metrics.bandHeight;
+    const middleHeight = metrics.sourceHeight;
+    paintSpan(0, middleTop, metrics.sideMargin, middleHeight);
+    paintSpan(metrics.sideMargin + metrics.sourceWidth, middleTop, metrics.sideMargin, middleHeight);
   }
 }
 
 function copyPhotoRegion(data, metrics, imageData) {
   const src = imageData.data;
-  if (metrics.isPortrait) {
-    for (let y = 0; y < metrics.sourceHeight; y++) {
-      const srcOffset = y * metrics.sourceWidth * 4;
-      const dstX = metrics.bandHeight;
-      const dstY = y + metrics.sideMargin;
-      const dstOffset = (dstY * metrics.outputWidth + dstX) * 4;
-      data.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
-    }
-  } else {
-    for (let y = 0; y < metrics.sourceHeight; y++) {
-      const srcOffset = y * metrics.sourceWidth * 4;
-      const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
-      data.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
-    }
+  for (let y = 0; y < metrics.sourceHeight; y++) {
+    const srcOffset = y * metrics.sourceWidth * 4;
+    const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
+    data.set(src.subarray(srcOffset, srcOffset + metrics.sourceWidth * 4), dstOffset);
   }
 }
 
 function clearPhotoRegion(data, metrics) {
-  if (metrics.isPortrait) {
-    for (let y = 0; y < metrics.sourceHeight; y++) {
-      const dstX = metrics.bandHeight;
-      const dstY = y + metrics.sideMargin;
-      const dstOffset = (dstY * metrics.outputWidth + dstX) * 4;
-      data.fill(0, dstOffset, dstOffset + metrics.sourceWidth * 4);
-    }
-  } else {
-    for (let y = 0; y < metrics.sourceHeight; y++) {
-      const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
-      data.fill(0, dstOffset, dstOffset + metrics.sourceWidth * 4);
-    }
+  for (let y = 0; y < metrics.sourceHeight; y++) {
+    const dstOffset = ((y + metrics.bandHeight) * metrics.outputWidth + metrics.sideMargin) * 4;
+    data.fill(0, dstOffset, dstOffset + metrics.sourceWidth * 4);
   }
 }
 
@@ -535,22 +489,11 @@ function paintSprocketHole(data, metrics, left, top, fill) {
 }
 
 function forEachSprocketHole(metrics, callback) {
-  if (metrics.isPortrait) {
-    // Portrait: holes are on left and right sides, running vertically
-    for (let i = 0; i < metrics.holeCount; i++) {
-      const holeIndex = (metrics.firstHoleIndex || 0) + i;
-      const top = (metrics.frameStartX ?? metrics.startX) + holeIndex * metrics.pitch;
-      callback(metrics.leftX, top, holeIndex);
-      callback(metrics.rightX, top, holeIndex);
-    }
-  } else {
-    // Landscape: holes on top and bottom
-    for (let i = 0; i < metrics.holeCount; i++) {
-      const holeIndex = (metrics.firstHoleIndex || 0) + i;
-      const left = (metrics.frameStartX ?? metrics.startX) + holeIndex * metrics.pitch;
-      callback(left, metrics.topY, holeIndex);
-      callback(left, metrics.bottomY, holeIndex);
-    }
+  for (let i = 0; i < metrics.holeCount; i++) {
+    const holeIndex = (metrics.firstHoleIndex || 0) + i;
+    const left = (metrics.frameStartX ?? metrics.startX) + holeIndex * metrics.pitch;
+    callback(left, metrics.topY, holeIndex);
+    callback(left, metrics.bottomY, holeIndex);
   }
 }
 
@@ -564,13 +507,8 @@ function roundedRectDistance(px, py, left, top, width, height, radius) {
   return outside + inside - radius;
 }
 
-function getSprocketBandClip(metrics, offset) {
-  if (metrics.isPortrait) {
-    return offset < metrics.bandHeight
-      ? { left: 0, right: metrics.bandHeight }
-      : { left: metrics.rightBandStart, right: metrics.outputWidth };
-  }
-  return offset < metrics.bandHeight
+function getSprocketBandClip(metrics, top) {
+  return top < metrics.bandHeight
     ? { top: 0, bottom: metrics.bandHeight }
     : { top: metrics.bottomBandTop, bottom: metrics.outputHeight };
 }
@@ -580,18 +518,10 @@ function paintSprocketGlow(data, metrics, left, top, fill, strength = 1) {
   if (amount <= 0) return;
   const spread = Math.max(4, Math.round(metrics.holeHeight * (0.42 + amount * 0.38)));
   const bandClip = getSprocketBandClip(metrics, top);
-  const isPortrait = metrics.isPortrait;
-
-  const rectLeft = Math.max(isPortrait ? (bandClip.left || 0) : 0, Math.round(left - spread));
-  const rectTop = Math.max(isPortrait ? 0 : (bandClip.top || 0), Math.round(top - spread));
-  const rectRight = Math.min(
-    isPortrait ? (bandClip.right || metrics.outputWidth) : metrics.outputWidth,
-    Math.round(left + metrics.holeWidth + spread)
-  );
-  const rectBottom = Math.min(
-    isPortrait ? metrics.outputHeight : (bandClip.bottom || metrics.outputHeight),
-    Math.round(top + metrics.holeHeight + spread)
-  );
+  const rectLeft = Math.max(0, Math.round(left - spread));
+  const rectTop = Math.max(bandClip.top, Math.round(top - spread));
+  const rectRight = Math.min(metrics.outputWidth, Math.round(left + metrics.holeWidth + spread));
+  const rectBottom = Math.min(bandClip.bottom, Math.round(top + metrics.holeHeight + spread));
 
   for (let y = rectTop; y < rectBottom; y++) {
     for (let x = rectLeft; x < rectRight; x++) {
@@ -601,10 +531,10 @@ function paintSprocketGlow(data, metrics, left, top, fill, strength = 1) {
       );
       if (distance < 0 || distance > spread) continue;
       const falloff = 1 - distance / spread;
-      const isNear = isPortrait ? (left < metrics.bandHeight) : (top < metrics.bandHeight);
-      const inward = isNear
-        ? clamp(isPortrait ? ((x - left) / Math.max(1, metrics.holeWidth + spread)) : ((y - top) / Math.max(1, metrics.holeHeight + spread)), 0, 1)
-        : clamp(isPortrait ? ((left + metrics.holeWidth - x) / Math.max(1, metrics.holeWidth + spread)) : ((top + metrics.holeHeight - y) / Math.max(1, metrics.holeHeight + spread)), 0, 1);
+      const isTopRow = top < metrics.bandHeight;
+      const inward = isTopRow
+        ? clamp((y - top) / Math.max(1, metrics.holeHeight + spread), 0, 1)
+        : clamp((top + metrics.holeHeight - y) / Math.max(1, metrics.holeHeight + spread), 0, 1);
       const localScale = Math.max(4, Math.round(metrics.holeHeight * 0.42));
       const coarse = smoothNoise(x - left, y - top, localScale, 914);
       const fine = hashNoise((x - left) * 1.7, (y - top) * 1.3, 915);
@@ -1243,11 +1173,59 @@ function createSprocketFrameImageData(imageData, options = {}, { includePhoto = 
   return new ImageData(output, metrics.outputWidth, metrics.outputHeight);
 }
 
+function isPortrait(imageData) {
+  return imageData && imageData.height > imageData.width;
+}
+
+function rotateImageData90(imageData) {
+  // Rotate 90° clockwise: landscape → portrait, or portrait → landscape
+  const srcW = imageData.width, srcH = imageData.height;
+  const dstW = srcH, dstH = srcW;
+  const src = imageData.data;
+  const dst = new Uint8ClampedArray(dstW * dstH * 4);
+  for (let y = 0; y < srcH; y++) {
+    for (let x = 0; x < srcW; x++) {
+      const si = (y * srcW + x) * 4;
+      const di = ((x) * dstW + (dstW - 1 - y)) * 4;
+      dst[di] = src[si]; dst[di + 1] = src[si + 1];
+      dst[di + 2] = src[si + 2]; dst[di + 3] = src[si + 3];
+    }
+  }
+  return new ImageData(dst, dstW, dstH);
+}
+
+function rotateImageData270(imageData) {
+  // Rotate 270° clockwise (90° counter-clockwise)
+  const srcW = imageData.width, srcH = imageData.height;
+  const dstW = srcH, dstH = srcW;
+  const src = imageData.data;
+  const dst = new Uint8ClampedArray(dstW * dstH * 4);
+  for (let y = 0; y < srcH; y++) {
+    for (let x = 0; x < srcW; x++) {
+      const si = (y * srcW + x) * 4;
+      const di = ((dstW - 1 - x) * dstW + y) * 4;
+      dst[di] = src[si]; dst[di + 1] = src[si + 1];
+      dst[di + 2] = src[si + 2]; dst[di + 3] = src[si + 3];
+    }
+  }
+  return new ImageData(dst, dstW, dstH);
+}
+
 export function composeSprocketFrame(imageData, options = {}) {
+  if (isPortrait(imageData)) {
+    const rotated = rotateImageData90(imageData);
+    const framed = createSprocketFrameImageData(rotated, options, { includePhoto: true });
+    return rotateImageData270(framed);
+  }
   return createSprocketFrameImageData(imageData, options, { includePhoto: true });
 }
 
 export function composeSprocketFrameBackground(imageData, options = {}) {
+  if (isPortrait(imageData)) {
+    const rotated = rotateImageData90(imageData);
+    const framed = createSprocketFrameImageData(rotated, options, { includePhoto: false });
+    return rotateImageData270(framed);
+  }
   return createSprocketFrameImageData(imageData, options, { includePhoto: false });
 }
 

--- a/negative2positive/src/app/sprocketFrame.js
+++ b/negative2positive/src/app/sprocketFrame.js
@@ -1196,6 +1196,7 @@ function rotateImageData90(imageData) {
 
 function rotateImageData270(imageData) {
   // Rotate 270° clockwise (90° counter-clockwise)
+  // Source (x,y) → Destination (dstH-1-x, y)
   const srcW = imageData.width, srcH = imageData.height;
   const dstW = srcH, dstH = srcW;
   const src = imageData.data;
@@ -1203,7 +1204,7 @@ function rotateImageData270(imageData) {
   for (let y = 0; y < srcH; y++) {
     for (let x = 0; x < srcW; x++) {
       const si = (y * srcW + x) * 4;
-      const di = ((dstW - 1 - x) * dstW + y) * 4;
+      const di = ((dstH - 1 - x) * dstW + y) * 4;
       dst[di] = src[si]; dst[di + 1] = src[si + 1];
       dst[di + 2] = src[si + 2]; dst[di + 3] = src[si + 3];
     }


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Portrait sprocket orientation
When the image is portrait (2:3), sprocket holes and film edge bands now appear on the **left and right** sides instead of top and bottom. Edge markings (text, DX codes, frame numbers, half-frame markers, overexposed sprockets) all adapt correctly.

Approach: `composeSprocketFrame` pre-rotates portrait input 90° CW to landscape, runs the full landscape composition pipeline (all markings work as-is), then post-rotates 270° CW back to portrait. No internal rendering code needs changes.

Preview falls through to the full compose path for portrait images.

### 2. Rotation preserves crop
Removed the `currentStep >= 3` guard — crop region is now preserved on rotation whenever a crop exists, at any step.

## Changes

| File | Change |
|------|--------|
| `sprocketFrame.js` | Pre/post rotate in compose functions, fix rotation formula |
| `main.js` | Portrait preview uses full compose, use framed dimensions for canvas, preserve crop on any step rotation |

## Test plan
- [x] Landscape image — sprocket preview: holes on top/bottom, markings correct
- [x] Portrait image — sprocket preview: holes on left/right, markings correct
- [x] Portrait export — sprocket holes on left/right
- [x] Rotate 90° after crop — crop preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)