### PR TITLE
fix: enable gray point picker in positive/slide mode

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -1605,7 +1605,7 @@
       if (!stateReady) return false;
       return state.currentStep >= 3
         && usesSilverCoreConversion(state)
-        && sanitizePresetType(state.filmType || 'color') === 'color';
+        && sanitizePresetType(state.filmType || 'color') !== 'bw';
     }
 
     function setFrontierGuidePopupVisible(visible) {


### PR DESCRIPTION
## Summary
- 正片模式下也可以点击画面中的灰点进行白平衡校正
- `isGrayPointGuideAvailable()` 条件从 `=== 'color'` 改为 `!== 'bw'`，使 color 和 positive 都能使用灰点取样

## Test plan
- [x] build 通过