### PR TITLE
fix: gray point picker + apply button visibility in positive mode

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -3594,6 +3594,8 @@
         state.currentStep === 1 ? 'inline-flex' : 'none';
       document.getElementById('convertPositiveBtn').style.display =
         state.currentStep === 1 ? 'inline-flex' : 'none';
+      document.getElementById('applyConvertBtn').style.display =
+        state.currentStep === 2 ? 'flex' : 'none';
 
       syncBatchUIState({ reason: 'updateWorkflowUI' });
       updateAutoFrameButtons();


### PR DESCRIPTION
## Summary
- 正片模式下灰点取样按钮可用（`isGrayPointGuideAvailable` 从 `=== 'color'` 改为 `!== 'bw'`）
- `applyConvertBtn` 只在 step 2 显示，进入 step 3 后自动隐藏，避免用户混淆

## Test plan
- [x] build 通过