### PR TITLE
Fix sprocket preview canvas switching

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -3851,16 +3851,12 @@
       const nextEnabled = Boolean(enabled);
       state.sprocketPreviewEnabled = nextEnabled;
       updateSprocketControlsUI();
+      updateCanvasVisibility();
 
       if (options.render === false) return;
       if (state.beforeAfterActive) exitBeforeAfter();
       if (state.currentStep >= 3 && state.processedImageData) {
-        // Draw the already-adjusted full-res buffer to canvas — no recompute, instant GPU copy.
-        const display = state.displayImageData || state.processedImageData;
-        renderAdjustedImageDataToMainCanvas(display, display, {
-          fastSprocketPreview: true
-        });
-        renderHistogram(display);
+        updatePreview();
         return;
       }
 
@@ -5240,6 +5236,9 @@
       if (!webglState.gl || webglState.disabledByError || !state.processedImageData) return false;
 
       try {
+        const source = getWebglSourceImageData();
+        if (!source) return false;
+        adjustCanvasDisplay(source.width, source.height);
         resizeWebGLCanvas();
 
         const gl = webglState.gl;
@@ -5247,8 +5246,6 @@
         gl.useProgram(webglState.program);
 
         // Uploads if needed
-        const source = getWebglSourceImageData();
-        if (!source) return false;
         if (webglState.sourceDirty || webglState.sourceSize.w !== source.width || webglState.sourceSize.h !== source.height) {
           webglUploadSource(source);
         }


### PR DESCRIPTION
## Summary
- keep the 2D canvas visible when sprocket preview is toggled on in Step 3
- restore the WebGL preview display size from the current image source when sprocket preview is toggled off
- prevent the non-sprocket preview from inheriting the sprocket frame aspect ratio

## Verification
- node negative2positive/src/app/sprocketFrame.test.mjs
- node negative2positive/src/app/imageDataOps.test.mjs
- npm run build:web
- Chrome DevTools: SAMPLE.jpg -> Positive Mode -> Step 3 -> Sprocket Preview on/off restores original preview aspect ratio