### PR TITLE
Fix export worker buffer detachment

### DIFF
--- a/negative2positive/src/workers/workerBridge.js
+++ b/negative2positive/src/workers/workerBridge.js
@@ -91,6 +91,11 @@ function serializeSettings(settings) {
   return copy;
 }
 
+function copyImageDataBuffer(imageData) {
+  const { buffer, byteOffset, byteLength } = imageData.data;
+  return buffer.slice(byteOffset, byteOffset + byteLength);
+}
+
 /**
  * Apply adjustments to image data via Worker.
  * @param {ImageData} imageData
@@ -101,7 +106,7 @@ function serializeSettings(settings) {
  */
 export async function workerApplyAdjustments(imageData, settings, quality = 'full', onProgress = null) {
   // Must copy: if worker fails, caller's fallback still needs the original buffer.
-  const inputBuffer = imageData.data.buffer.slice(0);
+  const inputBuffer = copyImageDataBuffer(imageData);
 
   try {
     const result = await sendToWorker(
@@ -130,15 +135,18 @@ export async function workerApplyAdjustments(imageData, settings, quality = 'ful
  * @returns {Promise<Blob>}
  */
 export async function workerEncodePng16(imageData, onProgress = null) {
+  // Transfer a copy so worker success/failure never detaches the caller's ImageData.
+  const pixelData = copyImageDataBuffer(imageData);
+
   try {
     return await sendToWorker(
       {
         type: 'encodePng16',
-        pixelData: imageData.data.buffer,
+        pixelData,
         width: imageData.width,
         height: imageData.height
       },
-      [imageData.data.buffer],
+      [pixelData],
       onProgress
     );
   } catch {
@@ -154,16 +162,19 @@ export async function workerEncodePng16(imageData, onProgress = null) {
  * @returns {Promise<Blob>}
  */
 export async function workerEncodeTiff(imageData, bitDepth = 8, onProgress = null) {
+  // Transfer a copy so worker success/failure never detaches the caller's ImageData.
+  const pixelData = copyImageDataBuffer(imageData);
+
   try {
     return await sendToWorker(
       {
         type: 'encodeTiff',
-        pixelData: imageData.data.buffer,
+        pixelData,
         width: imageData.width,
         height: imageData.height,
         bitDepth
       },
-      [imageData.data.buffer],
+      [pixelData],
       onProgress
     );
   } catch {

--- a/negative2positive/src/workers/workerBridge.test.mjs
+++ b/negative2positive/src/workers/workerBridge.test.mjs
@@ -1,0 +1,79 @@
+// Standalone Node test for workerBridge.js - run with:
+// node negative2positive/src/workers/workerBridge.test.mjs
+import assert from 'node:assert/strict';
+
+let lastPost = null;
+
+class FakeWorker {
+  constructor() {
+    this.onmessage = null;
+    this.onerror = null;
+  }
+
+  postMessage(message, transfers = []) {
+    lastPost = { message, transfers };
+    structuredClone(message, { transfer: transfers });
+    queueMicrotask(() => {
+      this.onmessage({
+        data: {
+          type: 'blobResult',
+          id: message.id,
+          blob: new Blob(['ok'])
+        }
+      });
+    });
+  }
+
+  terminate() {}
+}
+
+globalThis.Worker = FakeWorker;
+globalThis.ImageData = class ImageData {
+  constructor(data, width, height) {
+    this.data = data;
+    this.width = width;
+    this.height = height;
+  }
+};
+
+const {
+  terminateWorker,
+  workerEncodePng16,
+  workerEncodeTiff
+} = await import('./workerBridge.js');
+
+function createImageData() {
+  return new ImageData(
+    new Uint8ClampedArray([
+      0, 64, 128, 255,
+      255, 128, 64, 255
+    ]),
+    2,
+    1
+  );
+}
+
+async function assertEncodePreservesImageDataBuffer(encode) {
+  terminateWorker();
+  lastPost = null;
+  const imageData = createImageData();
+  const originalBuffer = imageData.data.buffer;
+  const originalLength = imageData.data.byteLength;
+
+  const blob = await encode(imageData);
+
+  assert.equal(blob.size, 2);
+  assert.ok(lastPost, 'expected worker postMessage to be called');
+  assert.equal(lastPost.transfers.length, 1);
+  assert.notEqual(lastPost.transfers[0], originalBuffer);
+  assert.equal(lastPost.transfers[0].byteLength, 0);
+  assert.equal(originalBuffer.byteLength, originalLength);
+  assert.equal(imageData.data.byteLength, originalLength);
+  assert.doesNotThrow(() => new Uint8ClampedArray(originalBuffer));
+}
+
+await assertEncodePreservesImageDataBuffer((imageData) => workerEncodePng16(imageData));
+await assertEncodePreservesImageDataBuffer((imageData) => workerEncodeTiff(imageData, 16));
+terminateWorker();
+
+console.log('workerBridge.test.mjs passed');


### PR DESCRIPTION
## Summary
- Copy `ImageData` buffers before transferring PNG/TIFF export work to the worker.
- Keep the caller-owned image buffer usable if the worker succeeds, fails, or falls back to main-thread encoding.
- Add a fake Worker regression test that simulates transferable detachment and verifies the original buffer remains constructible.

## Tests
- `node negative2positive/src/workers/workerBridge.test.mjs`
- `node negative2positive/src/app/exportImageEncoders.test.mjs`
- `npm run build:web`
