### PR TITLE
deps: switch libraw-wasm from GitHub fork to npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@techstark/opencv-js": "4.12.0-release.1",
         "@vercel/analytics": "^2.0.1",
         "jszip": "3.10.1",
-        "libraw-wasm": "github:lexluthor0304/LibRaw-Wasm",
+        "libraw-wasm": "^1.5.0",
         "pako": "2.1.0",
         "three": "^0.183.2",
         "upng-js": "2.1.0",
@@ -1533,8 +1533,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/libraw-wasm": {
-      "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/lexluthor0304/LibRaw-Wasm.git#c17e6ffa83f176497f07a90e740fca495ce0eca3",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/libraw-wasm/-/libraw-wasm-1.5.0.tgz",
+      "integrity": "sha512-dYNuOnuGQVq6ldkOLoHz5BrY63aewpEuLaAfJdv7pxrfdHrtRxzuWywAmtwRDU3UB66Gl4Hk33N1qG/HjV1oXA==",
       "license": "ISC"
     },
     "node_modules/lie": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@techstark/opencv-js": "4.12.0-release.1",
     "@vercel/analytics": "^2.0.1",
     "jszip": "3.10.1",
-    "libraw-wasm": "github:lexluthor0304/LibRaw-Wasm",
+    "libraw-wasm": "^1.5.0",
     "pako": "2.1.0",
     "three": "^0.183.2",
     "upng-js": "2.1.0",


### PR DESCRIPTION
Switch `libraw-wasm` from `github:lexluthor0304/LibRaw-Wasm` (fork) to `^1.5.0` from npm registry.

No more manual fork maintenance needed — `npm update` handles future versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)