### PR TITLE
Restore header GitHub star count without third-party iframe

### DIFF
--- a/negative2positive/index.html
+++ b/negative2positive/index.html
@@ -114,16 +114,17 @@
       <span class="header-copyright">
         © <span id="copyrightYear">2026</span> <a href="https://neoanaloglab.com" target="_blank">neoanaloglab.com</a>
         <span class="github-link">
-          <a class="github-star-btn" href="https://github.com/lexluthor0304/NegativeConverter" target="_blank" rel="noopener"
-            aria-label="Star lexluthor0304/NegativeConverter on GitHub">
-            <span class="github-star-btn-main">
+          <span class="github-star-btn">
+            <a class="github-star-btn-main" href="https://github.com/lexluthor0304/NegativeConverter" target="_blank" rel="noopener"
+              aria-label="Star lexluthor0304/NegativeConverter on GitHub">
               <svg viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
               </svg>
               Star
-            </span>
-            <span class="github-star-btn-count" id="githubStarCount" hidden></span>
-          </a>
+            </a>
+            <a class="github-star-btn-count" id="githubStarCount"
+              href="https://github.com/lexluthor0304/NegativeConverter/stargazers" target="_blank" rel="noopener" hidden></a>
+          </span>
         </span>
       </span>
     </div>
@@ -1190,6 +1191,7 @@
       const CACHE_TTL = 6 * 60 * 60 * 1000;
       const render = (count) => {
         countEl.textContent = count >= 1000 ? (count / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(count);
+        countEl.setAttribute('aria-label', count + ' stargazers on GitHub');
         countEl.hidden = false;
       };
       let cached = null;

--- a/negative2positive/index.html
+++ b/negative2positive/index.html
@@ -1186,7 +1186,8 @@
     // GitHub star count (official REST API, cached locally to stay well under the rate limit)
     (function loadGithubStars() {
       const countEl = document.getElementById('githubStarCount');
-      if (!countEl) return;
+      const hostEl = document.querySelector('.header-copyright');
+      if (!countEl || !hostEl) return;
       const CACHE_KEY = 'nc_github_stars';
       const CACHE_TTL = 6 * 60 * 60 * 1000;
       const render = (count) => {
@@ -1194,20 +1195,30 @@
         countEl.setAttribute('aria-label', count + ' stargazers on GitHub');
         countEl.hidden = false;
       };
-      let cached = null;
-      try { cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch (err) { /* ignore */ }
-      if (cached && typeof cached.count === 'number') render(cached.count);
-      if (cached && Date.now() - cached.at < CACHE_TTL) return;
-      fetch('https://api.github.com/repos/lexluthor0304/NegativeConverter')
-        .then(res => (res.ok ? res.json() : null))
-        .then(data => {
-          if (!data || typeof data.stargazers_count !== 'number') return;
-          render(data.stargazers_count);
-          try {
-            localStorage.setItem(CACHE_KEY, JSON.stringify({ count: data.stargazers_count, at: Date.now() }));
-          } catch (err) { /* ignore */ }
-        })
-        .catch(() => { /* offline / blocked: keep the plain Star button */ });
+      let requested = false;
+      const load = () => {
+        // The header copyright block is hidden on narrow viewports; don't spend a
+        // GitHub API request (or leak one) for a count nobody can see.
+        if (requested || getComputedStyle(hostEl).display === 'none') return;
+        requested = true;
+        window.removeEventListener('resize', load);
+        let cached = null;
+        try { cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch (err) { /* ignore */ }
+        if (cached && typeof cached.count === 'number') render(cached.count);
+        if (cached && Date.now() - cached.at < CACHE_TTL) return;
+        fetch('https://api.github.com/repos/lexluthor0304/NegativeConverter')
+          .then(res => (res.ok ? res.json() : null))
+          .then(data => {
+            if (!data || typeof data.stargazers_count !== 'number') return;
+            render(data.stargazers_count);
+            try {
+              localStorage.setItem(CACHE_KEY, JSON.stringify({ count: data.stargazers_count, at: Date.now() }));
+            } catch (err) { /* ignore */ }
+          })
+          .catch(() => { /* offline / blocked: keep the plain Star button */ });
+      };
+      load();
+      if (!requested) window.addEventListener('resize', load);
     })();
   </script>
   <script type="module" src="./src/app/main.js"></script>

--- a/negative2positive/index.html
+++ b/negative2positive/index.html
@@ -114,13 +114,16 @@
       <span class="header-copyright">
         © <span id="copyrightYear">2026</span> <a href="https://neoanaloglab.com" target="_blank">neoanaloglab.com</a>
         <span class="github-link">
-          <iframe
-            src="https://ghbtns.com/github-btn.html?user=lexluthor0304&repo=NegativeConverter&type=star&count=true&size=small"
-            width="120"
-            height="20"
-            title="GitHub stars for NegativeConverter"
-            loading="lazy">
-          </iframe>
+          <a class="github-star-btn" href="https://github.com/lexluthor0304/NegativeConverter" target="_blank" rel="noopener"
+            aria-label="Star lexluthor0304/NegativeConverter on GitHub">
+            <span class="github-star-btn-main">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+              </svg>
+              Star
+            </span>
+            <span class="github-star-btn-count" id="githubStarCount" hidden></span>
+          </a>
         </span>
       </span>
     </div>
@@ -1178,6 +1181,32 @@
   <div id="toastContainer"></div>
   <script>
     document.getElementById('copyrightYear').textContent = new Date().getFullYear();
+
+    // GitHub star count (official REST API, cached locally to stay well under the rate limit)
+    (function loadGithubStars() {
+      const countEl = document.getElementById('githubStarCount');
+      if (!countEl) return;
+      const CACHE_KEY = 'nc_github_stars';
+      const CACHE_TTL = 6 * 60 * 60 * 1000;
+      const render = (count) => {
+        countEl.textContent = count >= 1000 ? (count / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(count);
+        countEl.hidden = false;
+      };
+      let cached = null;
+      try { cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch (err) { /* ignore */ }
+      if (cached && typeof cached.count === 'number') render(cached.count);
+      if (cached && Date.now() - cached.at < CACHE_TTL) return;
+      fetch('https://api.github.com/repos/lexluthor0304/NegativeConverter')
+        .then(res => (res.ok ? res.json() : null))
+        .then(data => {
+          if (!data || typeof data.stargazers_count !== 'number') return;
+          render(data.stargazers_count);
+          try {
+            localStorage.setItem(CACHE_KEY, JSON.stringify({ count: data.stargazers_count, at: Date.now() }));
+          } catch (err) { /* ignore */ }
+        })
+        .catch(() => { /* offline / blocked: keep the plain Star button */ });
+    })();
   </script>
   <script type="module" src="./src/app/main.js"></script>
 </body>

--- a/negative2positive/src/styles/app.css
+++ b/negative2positive/src/styles/app.css
@@ -3548,7 +3548,49 @@ input.preset-select {
   vertical-align: middle;
 }
 
-.header-copyright .github-link iframe {
-  display: block;
-  border: 0;
+.header-copyright .github-star-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  text-decoration: none;
+}
+
+.header-copyright .github-star-btn:hover {
+  text-decoration: none;
+}
+
+.github-star-btn-main,
+.github-star-btn-count {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 7px;
+  border: 1px solid #d1d9e0;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #f6f8fa 0%, #eaeef2 100%);
+  color: #1f2328;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
+.github-star-btn-main {
+  gap: 4px;
+}
+
+.github-star-btn-main svg {
+  width: 13px;
+  height: 13px;
+  fill: currentColor;
+}
+
+.github-star-btn:hover .github-star-btn-main {
+  background: linear-gradient(180deg, #ffffff 0%, #eef1f4 100%);
+  border-color: #b8c0c8;
+}
+
+.github-star-btn-count[hidden] {
+  display: none;
 }

--- a/negative2positive/src/styles/app.css
+++ b/negative2positive/src/styles/app.css
@@ -3552,15 +3552,10 @@ input.preset-select {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  text-decoration: none;
 }
 
-.header-copyright .github-star-btn:hover {
-  text-decoration: none;
-}
-
-.github-star-btn-main,
-.github-star-btn-count {
+.header-copyright .github-star-btn-main,
+.header-copyright .github-star-btn-count {
   display: inline-flex;
   align-items: center;
   height: 20px;
@@ -3574,23 +3569,27 @@ input.preset-select {
   font-weight: 700;
   letter-spacing: 0.02em;
   line-height: 1;
+  text-decoration: none;
 }
 
-.github-star-btn-main {
+.header-copyright .github-star-btn-main {
   gap: 4px;
 }
 
-.github-star-btn-main svg {
+.header-copyright .github-star-btn-main svg {
   width: 13px;
   height: 13px;
   fill: currentColor;
 }
 
-.github-star-btn:hover .github-star-btn-main {
+.header-copyright .github-star-btn-main:hover,
+.header-copyright .github-star-btn-count:hover {
   background: linear-gradient(180deg, #ffffff 0%, #eef1f4 100%);
   border-color: #b8c0c8;
+  color: #0969da;
+  text-decoration: none;
 }
 
-.github-star-btn-count[hidden] {
+.header-copyright .github-star-btn-count[hidden] {
   display: none;
 }


### PR DESCRIPTION
## 背景

アプリヘッダーの GitHub スターボタンが Safari で表示されなくなっていた。原因は `ghbtns.com` の iframe（GitHub Buttons）埋め込みで、Safari の Intelligent Tracking Prevention やコンテンツブロッカーがこのクロスサイト iframe をブロックするため。Chrome では表示されるため気づきにくい状態だった。

## 変更内容

サードパーティ iframe を廃止し、GitHub 公式のパーツで自前描画に置き換え。

- `negative2positive/index.html`
  - 公式 Octicon（`mark-github`）+ `Star` ラベル + カウントバッジのマークアップを追加
  - スター数は GitHub 公式 REST API（`api.github.com/repos/...`、CORS 許可済み）から取得
  - localStorage に 6 時間キャッシュしてレート制限（未認証 60 req/h）を回避
  - 取得失敗時（オフライン / Tauri / レート制限）はカウントを隠し、`Star` リンクのみ表示する graceful fallback
- `negative2positive/src/styles/app.css`
  - iframe 用ルールを差し替え。見た目は従来の GitHub 公式ボタンと同等（フォントのみテーマの Orbitron に統一）
  - 900px 以下でヘッダーごと非表示になる既存の挙動は維持

## 確認

- ローカル dev サーバーで従来と同じ見た目・カウント表示を確認
- `npm test` 16/16 パス
- `npm run build:web` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQMW2oyZrzyeC2eNTyXjtX