### PR TITLE
Skip Vercel builds for feedback image commits

### DIFF
--- a/negative2positive/api/feedback.mjs
+++ b/negative2positive/api/feedback.mjs
@@ -33,7 +33,9 @@ async function uploadImages(repo, token, images) {
         method: 'PUT',
         headers: githubHeaders(token),
         body: JSON.stringify({
-          message: `Add feedback image ${stamp}-${i + 1}`,
+          // [vercel skip] keeps the Git integration from spawning a doomed
+          // build of the assets-only branch on every image commit.
+          message: `Add feedback image ${stamp}-${i + 1} [vercel skip]`,
           content: img.data,
           branch: ASSETS_BRANCH,
         }),


### PR DESCRIPTION
## Summary
Every screenshot committed to the assets-only `feedback-assets` branch was triggering a doomed ~180ms Error build through the Vercel Git integration (the branch has no app to build). Tag image commit messages with `[vercel skip]` so Vercel ignores them.

## Testing
- `npm test` 19/19, handler image smoke all pass
- Production verification after merge: submit feedback with an image → confirm no new Preview build appears for the assets commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEYpCZPG1FxJ5dStrDh8e3