### PR TITLE
Remove ineffective [vercel skip] tag from image commits

### DIFF
--- a/negative2positive/api/feedback.mjs
+++ b/negative2positive/api/feedback.mjs
@@ -33,9 +33,9 @@ async function uploadImages(repo, token, images) {
         method: 'PUT',
         headers: githubHeaders(token),
         body: JSON.stringify({
-          // [vercel skip] keeps the Git integration from spawning a doomed
-          // build of the assets-only branch on every image commit.
-          message: `Add feedback image ${stamp}-${i + 1} [vercel skip]`,
+          // The assets branch carries a vercel.json with git.deploymentEnabled
+          // false, so these commits don't spawn doomed builds.
+          message: `Add feedback image ${stamp}-${i + 1}`,
           content: img.data,
           branch: ASSETS_BRANCH,
         }),


### PR DESCRIPTION
## Summary
Follow-up to #121: Vercel has no commit-message skip mechanism, so the `[vercel skip]` tag did nothing (an Error preview still appeared per image commit). The actual fix is a `vercel.json` with `{"git":{"deploymentEnabled":false}}` committed to the `feedback-assets` branch itself (done directly on that branch). This PR drops the misleading tag and updates the comment.

## Testing
- Production E2E after merge: image feedback submission must produce no new deployment for the assets commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEYpCZPG1FxJ5dStrDh8e3