### PR TITLE
Bump version to 1.0.0 for the App Store release

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "negative-converter"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "base64 0.22.1",
  "rfd",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "negative-converter"
-version = "0.1.0"
+version = "1.0.0"
 description = "Film negative to positive converter"
 authors = ["neoanaloglab"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Negative Converter",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "identifier": "com.neoanaloglab.negativeconverter",
   "build": {
     "beforeDevCommand": "npm run dev:web",


### PR DESCRIPTION
App Store Connect associates an uploaded build with the app version whose string matches `CFBundleShortVersionString`, so the bundle and the store listing have to agree. The store record was created at `1.0`; `1.0.0` is the closest value `desktop-release.yml`'s semver check accepts, and the App Store Connect listing has been updated to `1.0.0` to match.

## Heads up

Merging this fires **Desktop Release**, which cuts a `v1.0.0` tag and GitHub Release with the Windows/Linux/macOS artifacts and refreshes `latest.json`. Existing desktop users will see an update prompt. That's intended — this is the 1.0 release.

## Verification

`npm run tauri:build:mas` at this version produced a signed universal `.pkg`; confirmed `CFBundleShortVersionString` is `1.0.0`, `lipo` shows x86_64 + arm64, the sandbox entitlement is present, `embedded.provisionprofile` is in the bundle, and `pkgutil --check-signature` resolves the installer chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQeoEQyiK1EGbzhSht2GTo