### PR TITLE
Auto-publish the Mac App Store build from CI

### DIFF
--- a/.github/scripts/set_mas_bundle_version.mjs
+++ b/.github/scripts/set_mas_bundle_version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const version = (process.argv[2] || '').trim();
+const attempt = Number(process.argv[3] || '1');
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error(`Invalid version '${version}'. Expected format: x.y.z`);
+  process.exit(1);
+}
+if (!Number.isInteger(attempt) || attempt < 1) {
+  console.error(`Invalid run attempt '${process.argv[3]}'. Expected a positive integer.`);
+  process.exit(1);
+}
+
+// Mac App Store build numbers must increase across *every* upload of the app,
+// not just within one version. Deriving the number from the release version
+// keeps it monotonic and far above the hand-numbered uploads ("1", "2") that
+// shipped 1.0.0; the run attempt digit lets a re-run of a failed submission
+// re-upload the same version with a fresh build number.
+const [major, minor, patch] = version.split('.').map(Number);
+const bundleVersion = String((major * 10000 + minor * 100 + patch) * 100 + (attempt - 1));
+
+const confPath = 'src-tauri/tauri.appstore.conf.json';
+const conf = JSON.parse(readFileSync(confPath, 'utf8'));
+conf.bundle = conf.bundle || {};
+conf.bundle.macOS = conf.bundle.macOS || {};
+conf.bundle.macOS.bundleVersion = bundleVersion;
+writeFileSync(confPath, `${JSON.stringify(conf, null, 2)}\n`, 'utf8');
+
+console.log(`Applied MAS bundleVersion: ${bundleVersion} (version ${version}, attempt ${attempt})`);

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -353,3 +353,176 @@ jobs:
             --prefix "negative-converter/release" \
             --tag "${TAG}" \
             --update-latest
+
+  mas-appstore:
+    name: Publish to Mac App Store
+    # Runs only after the GitHub release exists, so a broken build on any
+    # platform blocks the App Store submission too and the computed version
+    # is guaranteed to be tagged.
+    runs-on: macos-latest
+    needs: [prepare, release]
+    timeout-minutes: 120
+
+    steps:
+      - name: Check App Store secrets
+        id: gate
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          MAS_CERT_DIST_P12: ${{ secrets.MAS_CERT_DIST_P12 }}
+          MAS_CERT_INSTALLER_P12: ${{ secrets.MAS_CERT_INSTALLER_P12 }}
+          MAS_CERT_PASSWORD: ${{ secrets.MAS_CERT_PASSWORD }}
+          MAS_PROVISION_PROFILE: ${{ secrets.MAS_PROVISION_PROFILE }}
+        run: |
+          missing=""
+          for name in ASC_API_KEY_ID ASC_API_ISSUER_ID ASC_API_KEY_P8 \
+              MAS_CERT_DIST_P12 MAS_CERT_INSTALLER_P12 MAS_CERT_PASSWORD MAS_PROVISION_PROFILE; do
+            [ -n "${!name}" ] || missing="${missing} ${name}"
+          done
+          if [ -n "${missing}" ]; then
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Mac App Store publish skipped; missing secrets:${missing}"
+          else
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          # Full history + tags for the release-notes diff against the previous tag.
+          fetch-depth: 0
+
+      - name: Apply release version
+        if: steps.gate.outputs.enabled == 'true'
+        run: node .github/scripts/set_tauri_version.mjs "${{ needs.prepare.outputs.version }}"
+
+      - name: Apply MAS bundle version
+        if: steps.gate.outputs.enabled == 'true'
+        run: node .github/scripts/set_mas_bundle_version.mjs "${{ needs.prepare.outputs.version }}" "${{ github.run_attempt }}"
+
+      - name: Setup Node
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Rust
+        if: steps.gate.outputs.enabled == 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Rust cache
+        if: steps.gate.outputs.enabled == 'true'
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true'
+        run: npm ci
+
+      - name: Import signing assets
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          MAS_CERT_DIST_P12: ${{ secrets.MAS_CERT_DIST_P12 }}
+          MAS_CERT_INSTALLER_P12: ${{ secrets.MAS_CERT_INSTALLER_P12 }}
+          MAS_CERT_PASSWORD: ${{ secrets.MAS_CERT_PASSWORD }}
+          MAS_PROVISION_PROFILE: ${{ secrets.MAS_PROVISION_PROFILE }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/mas-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          for var in MAS_CERT_DIST_P12 MAS_CERT_INSTALLER_P12; do
+            CERT_PATH="$RUNNER_TEMP/$var.p12"
+            echo "${!var}" | base64 --decode > "$CERT_PATH"
+            security import "$CERT_PATH" \
+              -P "$MAS_CERT_PASSWORD" \
+              -A -t cert -f pkcs12 \
+              -k "$KEYCHAIN_PATH"
+            rm -f "$CERT_PATH"
+          done
+
+          # Both identities chain to the WWDR G3 intermediate; macOS ships
+          # only the Apple root, so import G3 to complete the chain.
+          curl -fsSL -o "$RUNNER_TEMP/AppleWWDRCAG3.cer" \
+            https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer
+          security import "$RUNNER_TEMP/AppleWWDRCAG3.cer" -t cert -k "$KEYCHAIN_PATH"
+
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          echo "$MAS_PROVISION_PROFILE" | base64 --decode > src-tauri/embedded.provisionprofile
+
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Build Mac App Store package
+        if: steps.gate.outputs.enabled == 'true'
+        run: npm run tauri:build:mas
+
+      - name: Collect build metadata
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="src-tauri/target/universal-apple-darwin/release/bundle/macos"
+          APP_PATH="$BUNDLE_DIR/Negative Converter.app"
+          PKG_PATH="$BUNDLE_DIR/NegativeConverter-appstore.pkg"
+          test -f "$PKG_PATH"
+
+          APP_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PATH/Contents/Info.plist")"
+          BUILD_NUMBER="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Contents/Info.plist")"
+
+          if [ "$APP_VERSION" != "${{ needs.prepare.outputs.version }}" ]; then
+            echo "Bundle version $APP_VERSION does not match release version ${{ needs.prepare.outputs.version }}" >&2
+            exit 1
+          fi
+
+          {
+            echo "PKG_PATH=$GITHUB_WORKSPACE/$PKG_PATH"
+            echo "APP_VERSION=$APP_VERSION"
+            echo "BUILD_NUMBER=$BUILD_NUMBER"
+          } >> "$GITHUB_ENV"
+
+      - name: Generate release notes
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.prepare.outputs.tag }}"
+          NOTES_PATH="$RUNNER_TEMP/release_notes.txt"
+          prev="$(git tag --list 'v*' --sort=-v:refname | grep -Fxv "$TAG" | head -n 1 || true)"
+          if [ -n "$prev" ] && git rev-parse -q --verify "$prev^{commit}" >/dev/null; then
+            git log --no-merges --pretty='format:- %s' "$prev..HEAD" | head -c 3500 > "$NOTES_PATH" || true
+          else
+            : > "$NOTES_PATH"
+          fi
+          echo "Release notes ($(wc -c < "$NOTES_PATH") bytes):"
+          cat "$NOTES_PATH" || true
+          echo "RELEASE_NOTES_PATH=$NOTES_PATH" >> "$GITHUB_ENV"
+
+      - name: Upload and submit to App Store
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          command -v fastlane >/dev/null || sudo gem install fastlane -N
+          fastlane mac mas_upload
+
+      - name: Cleanup signing keychain
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "${KEYCHAIN_PATH}" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ NegativeConverter is a browser-based film negative to positive converter. It pro
 
 This project now uses **Vite** for web dev/build and Tauri for desktop packaging.
 
+Merging to `main` auto-releases the desktop app (GitHub Release + R2), and —
+when the App Store secrets are configured — builds, uploads, and submits the
+Mac App Store version too (see `docs/mas-release.md`).
+
 Run locally:
 ```bash
 npm ci

--- a/docs/mas-release.md
+++ b/docs/mas-release.md
@@ -1,0 +1,64 @@
+# Mac App Store auto-release
+
+Every push to `main` runs `.github/workflows/desktop-release.yml`. After the
+GitHub Release + R2 sync succeed, the `mas-appstore` job builds the sandboxed
+Mac App Store package (`scripts/build-mas.sh`), uploads it with fastlane
+(`fastlane/Fastfile`, lane `mac mas_upload`), submits it for review, and lets
+it release automatically once Apple approves. If any required secret is
+missing the job skips with a notice instead of failing.
+
+The web app on Vercel deploys on every merge regardless; this pipeline only
+concerns the packaged desktop app.
+
+## Required GitHub secrets
+
+| Secret | Content |
+| --- | --- |
+| `ASC_API_KEY_ID` | App Store Connect API key ID |
+| `ASC_API_ISSUER_ID` | App Store Connect issuer ID |
+| `ASC_API_KEY_P8` | **base64** of the `AuthKey_*.p8` file |
+| `MAS_CERT_DIST_P12` | **base64** of the `Apple Distribution: NEO ANALOG LABO K.K.` identity (.p12 with private key) |
+| `MAS_CERT_INSTALLER_P12` | **base64** of the `3rd Party Mac Developer Installer: NEO ANALOG LABO K.K.` identity (.p12 with private key) |
+| `MAS_CERT_PASSWORD` | export password shared by both .p12 files |
+| `MAS_PROVISION_PROFILE` | **base64** of `embedded.provisionprofile` (Mac App Store provisioning profile) |
+
+Create the API key in App Store Connect → Users and Access → Integrations →
+App Store Connect API → Team Keys → Generate (role: App Manager). Export the
+two identities from Keychain Access → My Certificates (use one password for
+both). The provisioning profile is the same file as the local, gitignored
+`src-tauri/embedded.provisionprofile`.
+
+## Versioning
+
+- The `prepare` job computes the release version by bumping the patch against
+  existing `v*` tags; `set_tauri_version.mjs` writes it into
+  `tauri.conf.json` / `Cargo.toml` as usual.
+- `set_mas_bundle_version.mjs` sets `CFBundleVersion` to
+  `(major*10000 + minor*100 + patch) * 100 + (run_attempt - 1)`
+  (e.g. `1.0.2` → `1000200`). Mac App Store build numbers must increase
+  across **all** uploads, and the attempt digit lets a re-run re-upload the
+  same version after a failed submission.
+- "What's New" is generated from `git log` between the previous tag and HEAD
+  (capped at 3500 chars, fallback "Bug fixes and improvements."), applied to
+  all locales.
+
+## Renewals
+
+- Signing certificates expire **2027-08-04**; the provisioning profile
+  expires annually. Re-export/download and update the secrets, and refresh
+  the local `src-tauri/embedded.provisionprofile` too.
+- The WWDR G3 intermediate is fetched from apple.com during the job; if Apple
+  rotates the issuing CA for renewed certificates, update that URL in the
+  `Import signing assets` step.
+
+## TestFlight
+
+Every uploaded build automatically becomes available to **internal** TestFlight
+testers (no extra CI work): create an internal group once in App Store Connect
+→ TestFlight and add yourself. Internal builds need no beta review, so this is
+the fastest way to run the latest merge on a Mac.
+
+## Manual fallback
+
+`npm run tauri:build:mas` still produces the signed .pkg locally, uploadable
+with Transporter.app — nothing in the pipeline removes the manual path.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,53 @@
+# Mac App Store release lane, driven by the mas-appstore job in
+# .github/workflows/desktop-release.yml (see docs/mas-release.md).
+#
+# Expects environment variables:
+#   ASC_API_KEY_ID / ASC_API_ISSUER_ID  - App Store Connect API key identity
+#   ASC_API_KEY_P8                      - base64-encoded AuthKey .p8
+#   PKG_PATH                            - absolute path to the signed MAS .pkg
+#   APP_VERSION                         - CFBundleShortVersionString (x.y.z)
+#   BUILD_NUMBER                        - CFBundleVersion of the uploaded build
+#   RELEASE_NOTES_PATH                  - optional file with "What's New" text
+
+opt_out_usage
+default_platform(:mac)
+
+platform :mac do
+  desc "Upload the signed .pkg to App Store Connect and submit for review"
+  lane :mas_upload do
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_API_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_API_ISSUER_ID"),
+      key_content: ENV.fetch("ASC_API_KEY_P8"),
+      is_key_content_base64: true
+    )
+
+    notes = ""
+    notes_path = ENV["RELEASE_NOTES_PATH"]
+    notes = File.read(notes_path).strip if notes_path && File.exist?(notes_path)
+    notes = "Bug fixes and improvements." if notes.empty?
+
+    deliver(
+      api_key: api_key,
+      app_identifier: "com.neoanaloglab.negativeconverter",
+      platform: "osx",
+      pkg: ENV.fetch("PKG_PATH"),
+      app_version: ENV.fetch("APP_VERSION"),
+      build_number: ENV.fetch("BUILD_NUMBER"),
+      # "default" applies the same notes to every enabled locale.
+      release_notes: { "default" => notes },
+      skip_screenshots: true,
+      run_precheck_before_submit: false,
+      precheck_include_in_app_purchases: false,
+      force: true,
+      reject_if_possible: true,
+      submit_for_review: true,
+      automatic_release: true,
+      submission_information: {
+        add_id_info_uses_idfa: false,
+        export_compliance_uses_encryption: false,
+        content_rights_contains_third_party_content: false
+      }
+    )
+  end
+end


### PR DESCRIPTION
Adds a mas-appstore job to the desktop release workflow: after the GitHub release it rebuilds the sandboxed universal .pkg, uploads it with fastlane via an App Store Connect API key, submits for review, and auto-releases on approval. Skips gracefully when secrets are absent. Setup/renewal docs in docs/mas-release.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7ZaxuMmD3odghd2CFvA2K