### PR TITLE
Let Dependabot watch npm, Cargo, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Keeps the three dependency layers of this repo current: the npm packages the
+# web app builds from, the Rust crates behind the Tauri shell, and the actions
+# the CI/release pipeline runs on. The actions layer is the one that drifted
+# worst without this (v4 while upstream was on v7/v8), because nothing else
+# surfaces it.
+#
+# Every merge to main triggers Desktop Release, which cuts a new patch version
+# (GitHub Release + R2 + Mac App Store submission). To keep that from turning
+# into a release per dependency, minor and patch updates are grouped into one PR
+# per ecosystem. Majors still arrive as individual PRs -- those need a real
+# review anyway, as the v4 -> v7/v8 actions jump showed.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # Cargo.toml keeps loose ranges ("2", "1", "0.22"), so most of this lands as
+  # Cargo.lock refreshes.
+  - package-ecosystem: cargo
+    directory: "/src-tauri"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/scripts/check-pinned-versions.mjs
+++ b/scripts/check-pinned-versions.mjs
@@ -1,0 +1,54 @@
+// Consistency checker for version numbers that live in two places at once.
+//
+// main.js pins @neoanaloglabkk/lensfun-wasm into a jsDelivr URL, so the copy the
+// browser fetches at runtime is a separate source of truth from the npm range the
+// bundle is built against. A dependency bump that only touches package.json would
+// silently leave the runtime on the old dist, so this catches that drift.
+//
+// Ranges are compared on their declared version (the caret is stripped), which is
+// what an automated bump rewrites.
+//
+//   node scripts/check-pinned-versions.mjs
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+
+const pins = [
+  {
+    dependency: '@neoanaloglabkk/lensfun-wasm',
+    constant: 'LENSFUN_PACKAGE_VERSION',
+    file: join('negative2positive', 'src', 'app', 'main.js'),
+  },
+];
+
+const problems = [];
+
+for (const { dependency, constant, file } of pins) {
+  const range = pkg.dependencies?.[dependency] ?? pkg.devDependencies?.[dependency];
+  if (!range) {
+    problems.push(`${dependency} is pinned in ${file} but missing from package.json`);
+    continue;
+  }
+  const declared = range.replace(/^[\^~>=<\s]+/, '');
+  const source = readFileSync(join(repoRoot, file), 'utf8');
+  const match = source.match(new RegExp(`const\\s+${constant}\\s*=\\s*['"\`]([^'"\`]+)['"\`]`));
+  if (!match) {
+    problems.push(`${constant} not found in ${file}`);
+    continue;
+  }
+  if (match[1] !== declared) {
+    problems.push(
+      `${file}: ${constant} is '${match[1]}' but package.json declares ${dependency}@${declared}`
+    );
+  }
+}
+
+if (problems.length) {
+  console.error(`Pinned version check: ${problems.length} problem(s)`);
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log(`Pinned version check: ${pins.length} pin(s) OK`);

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -21,8 +21,10 @@ function walk(dir) {
 }
 roots.forEach(walk);
 
-// SEO head consistency counts as part of the suite
-tests.push(join(dirname(fileURLToPath(import.meta.url)), 'check-seo-heads.mjs'));
+// Repo-wide consistency checks count as part of the suite
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+tests.push(join(scriptsDir, 'check-seo-heads.mjs'));
+tests.push(join(scriptsDir, 'check-pinned-versions.mjs'));
 
 let failed = 0;
 for (const t of tests) {


### PR DESCRIPTION
Follow-up to #134. Nothing in this repo surfaced stale dependencies, which is how the GitHub Actions drifted to v4 while upstream had moved to v7/v8. Dependabot now watches all three layers.

## Config
| ecosystem | directory | schedule |
| --- | --- | --- |
| npm | `/` | weekly, Mon 09:00 JST |
| cargo | `/src-tauri` | weekly, Mon 09:00 JST |
| github-actions | `/` | weekly, Mon 09:00 JST |

**Grouping matters here.** Every merge to main triggers Desktop Release, which cuts a new patch version — GitHub Release + R2 + Mac App Store submission. Ungrouped, a quiet week of five dependency bumps would mean five releases and five App Store submissions. So minor and patch updates are grouped into a single PR per ecosystem; majors still arrive individually because they need a real review, as the v4 → v7/v8 jump showed. Security updates are unaffected by the schedule — Dependabot opens those immediately.

Even so, expect up to three release-triggering merges on a busy Monday. If that's too much, batching the week's PRs onto one branch before merging keeps it to a single release.

## A trap automated bumps would have walked into
`main.js` pins `@neoanaloglabkk/lensfun-wasm` into a jsDelivr URL:

```js
const LENSFUN_PACKAGE_VERSION = '0.1.3';
const LENSFUN_CDN_BASE = `https://cdn.jsdelivr.net/npm/@neoanaloglabkk/lensfun-wasm@${LENSFUN_PACKAGE_VERSION}/dist`;
```

That makes the dist the browser fetches at runtime a second source of truth alongside the npm range the bundle builds against. A bump touching only `package.json` would leave the runtime loading the old dist, and nothing — build, tests, smoke test — would fail.

`scripts/check-pinned-versions.mjs` asserts the two agree, in the style of the existing `check-seo-heads.mjs`, and joins the suite via `run-tests.mjs`. Verified both directions: it passes on the current tree, and forcing the constant to `0.1.2` produces

```
Pinned version check: 1 problem(s)
  - negative2positive/src/app/main.js: LENSFUN_PACKAGE_VERSION is '0.1.2' but package.json declares @neoanaloglabkk/lensfun-wasm@0.1.3
```

with exit 1. Suite is now 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ci5TNGa5HH6LN78ERN1Qu