### PR TITLE
Stash the embedded JPEG preview before LibRaw detaches the RAW buffer

### DIFF
--- a/negative2positive/src/app/main.js
+++ b/negative2positive/src/app/main.js
@@ -5405,8 +5405,11 @@
           if (isHeavy) {
             // Two-stage loading: show fast half-size preview immediately,
             // then decode full resolution in the background.
+            // The preview stage gets a COPY: LibRaw transfers its input buffer
+            // to a worker, which would detach arrayBuffer and break the
+            // full-resolution decode scheduled below.
             overlay.updateProgress(20, lang.loadingProcessing);
-            imageData = await loadRawImageDataPreview(arrayBuffer, fileName, {
+            imageData = await loadRawImageDataPreview(arrayBuffer.slice(0), fileName, {
               onMetadata(meta) {
                 extractedRawMeta = meta;
               }

--- a/negative2positive/src/app/nefJpegPreview.js
+++ b/negative2positive/src/app/nefJpegPreview.js
@@ -153,15 +153,41 @@ export function extractNefPreviewJpeg(arrayBuffer) {
 export async function tryNefJpegPreview(arrayBuffer) {
   const extracted = extractNefPreviewJpeg(arrayBuffer);
   if (!extracted) return null;
-  const { jpegBytes, width, height } = extracted;
 
   // Slice into a standalone ArrayBuffer so the Blob doesn't pin the entire
   // RAW container in memory while createImageBitmap is decoding.
+  let standalone;
+  try {
+    standalone = new Uint8Array(extracted.jpegBytes.byteLength);
+    standalone.set(extracted.jpegBytes);
+  } catch (err) {
+    console.warn('[NEF fallback] failed to wrap JPEG bytes:', err);
+    return null;
+  }
+  return decodeNefPreviewJpeg({
+    jpegBytes: standalone,
+    width: extracted.width,
+    height: extracted.height,
+  });
+}
+
+/**
+ * Decode an already-extracted (and already-standalone) preview JPEG into
+ * ImageData. Split from tryNefJpegPreview so callers can stash the extracted
+ * bytes BEFORE handing the container to LibRaw — LibRaw transfers the
+ * container ArrayBuffer to its worker, which detaches it on this thread and
+ * makes any later extraction from it silently return nothing.
+ *
+ * @param {{ jpegBytes: Uint8Array, width?: number, height?: number } | null} extracted
+ * @returns {Promise<ImageData | null>}
+ */
+export async function decodeNefPreviewJpeg(extracted) {
+  if (!extracted || !extracted.jpegBytes || extracted.jpegBytes.byteLength < 4) return null;
+  const { jpegBytes, width, height } = extracted;
+
   let blob;
   try {
-    const standalone = new Uint8Array(jpegBytes.byteLength);
-    standalone.set(jpegBytes);
-    blob = new Blob([standalone], { type: 'image/jpeg' });
+    blob = new Blob([jpegBytes], { type: 'image/jpeg' });
   } catch (err) {
     console.warn('[NEF fallback] failed to wrap JPEG bytes:', err);
     return null;

--- a/negative2positive/src/app/nefJpegPreview.test.mjs
+++ b/negative2positive/src/app/nefJpegPreview.test.mjs
@@ -1,0 +1,80 @@
+// Tests for the embedded-JPEG preview extractor.
+// Standalone node assert script, discovered by scripts/run-tests.mjs.
+//
+// The detach test documents the failure mode behind the Zf/Z8/Z9 fallback
+// regression: LibRaw transfers the container ArrayBuffer to its worker, so
+// extraction attempted AFTER open() sees a zero-length buffer and finds
+// nothing. rawFileLoader must extract BEFORE handing the buffer to LibRaw.
+import assert from 'node:assert/strict';
+import { extractNefPreviewJpeg, readJpegDimensionsFromSOF } from './nefJpegPreview.js';
+
+// Minimal well-formed JPEG header: SOI + APP0(JFIF) + SOF0 (1620x1080, 3 comp).
+function makeJpegHeader(width, height) {
+  const app0 = [0xFF, 0xE0, 0x00, 0x10,
+    0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00];
+  // fix APP0 length: segment is 16 bytes (0x10) => payload 14 bytes after len
+  const sof0 = [0xFF, 0xC0, 0x00, 0x11, 0x08,
+    (height >> 8) & 0xFF, height & 0xFF,
+    (width >> 8) & 0xFF, width & 0xFF,
+    0x03,
+    0x01, 0x22, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01];
+  return Uint8Array.from([0xFF, 0xD8, ...app0, ...sof0]);
+}
+
+/** A fake RAW container: junk, a small thumbnail, junk, a big preview, junk. */
+function makeContainer() {
+  const container = new Uint8Array(64 * 1024);
+  for (let i = 0; i < container.length; i++) container[i] = (i * 31) & 0xFF;
+  // Erase accidental FF D8 FF patterns from the junk fill
+  for (let i = 0; i < container.length - 2; i++) {
+    if (container[i] === 0xFF && container[i + 1] === 0xD8) container[i + 1] = 0x00;
+  }
+  const thumb = makeJpegHeader(320, 240);   // below MIN_PREVIEW_WIDTH — must be skipped
+  const preview = makeJpegHeader(1620, 1080);
+  container.set(thumb, 1024);
+  const previewOffset = 32 * 1024;
+  container.set(preview, previewOffset);
+  return { buffer: container.buffer, previewOffset };
+}
+
+// --- SOF parser reads dimensions -------------------------------------------
+{
+  const jpeg = makeJpegHeader(1620, 1080);
+  const dims = readJpegDimensionsFromSOF(jpeg.buffer, 0, jpeg.byteLength);
+  assert.deepEqual(dims, { w: 1620, h: 1080 });
+}
+
+// --- extractor finds the largest usable preview, skipping thumbnails --------
+{
+  const { buffer, previewOffset } = makeContainer();
+  const extracted = extractNefPreviewJpeg(buffer);
+  assert.ok(extracted, 'expected a preview');
+  assert.equal(extracted.width, 1620);
+  assert.equal(extracted.height, 1080);
+  // jpegBytes must start at the preview's SOI
+  assert.equal(extracted.jpegBytes[0], 0xFF);
+  assert.equal(extracted.jpegBytes[1], 0xD8);
+  assert.equal(extracted.jpegBytes.byteOffset, previewOffset);
+}
+
+// --- a detached container yields null (the LibRaw-transfer failure mode) ----
+{
+  const { buffer } = makeContainer();
+  assert.ok(extractNefPreviewJpeg(buffer), 'sanity: works before detach');
+  if (typeof buffer.transfer === 'function') {
+    buffer.transfer(); // detaches `buffer`, like postMessage with a transfer list
+    assert.equal(buffer.byteLength, 0, 'buffer must be detached');
+    assert.equal(extractNefPreviewJpeg(buffer), null,
+      'extraction after detach must return null — callers must stash BEFORE LibRaw.open()');
+  }
+}
+
+// --- degenerate inputs ------------------------------------------------------
+{
+  assert.equal(extractNefPreviewJpeg(null), null);
+  assert.equal(extractNefPreviewJpeg(new ArrayBuffer(8)), null);
+  const noJpeg = new Uint8Array(4096).fill(0x42);
+  assert.equal(extractNefPreviewJpeg(noJpeg.buffer), null);
+}
+
+console.log('nefJpegPreview tests: all passed');

--- a/negative2positive/src/app/rawFileLoader.js
+++ b/negative2positive/src/app/rawFileLoader.js
@@ -7,7 +7,7 @@ import {
   toImageData8
 } from '../silvercore/util/image16.js';
 import { looksLikeBayerSnow } from '../silvercore/util/garbledCheck.js';
-import { tryNefJpegPreview } from './nefJpegPreview.js';
+import { tryNefJpegPreview, extractNefPreviewJpeg, decodeNefPreviewJpeg } from './nefJpegPreview.js';
 
 const UTIF = (UTIFImport && typeof UTIFImport.decode === 'function')
   ? UTIFImport
@@ -176,15 +176,31 @@ export async function loadRawFile(buffer, fileName, options = {}) {
     throw new Error(`module worker not supported: ${err?.message || err}`);
   }
 
+  // LibRaw transfers the container ArrayBuffer to its worker on open(), which
+  // DETACHES `buffer` on this thread (byteLength drops to 0). Anything the
+  // fallback paths need must therefore be copied out first — extracting after
+  // open() silently finds nothing, which is exactly how the Zf/Z8/Z9
+  // high-efficiency fallback regressed. The copy is the JPEG tail only, and
+  // it is short-lived (function scope).
+  let stashedPreview = null;
+  try {
+    const extracted = extractNefPreviewJpeg(buffer);
+    if (extracted) {
+      const jpegCopy = new Uint8Array(extracted.jpegBytes.byteLength);
+      jpegCopy.set(extracted.jpegBytes);
+      stashedPreview = { jpegBytes: jpegCopy, width: extracted.width, height: extracted.height };
+    }
+  } catch {}
+
   const killWorker = () => {
     try { raw.worker?.terminate?.(); } catch {}
   };
 
   const handleTimeoutFallback = async () => {
     killWorker();
-    const previewImageData = await tryNefJpegPreview(buffer);
+    const previewImageData = await decodeNefPreviewJpeg(stashedPreview);
     if (previewImageData) {
-      console.warn('[RAW] LibRaw timed out — using embedded preview (8-bit precision).');
+      console.warn('[RAW] LibRaw could not decode this file — using embedded preview (8-bit precision).');
       previewImageData.__image16 = fromImageData8(previewImageData);
       if (onMetadata) onMetadata(null);
       return previewImageData;
@@ -270,7 +286,7 @@ export async function loadRawFile(buffer, fileName, options = {}) {
 
   if (looksLikeBayerSnow(image16)) {
     console.warn('[RAW] decoded output looks un-demosaiced; trying embedded JPEG preview fallback');
-    const previewImageData = await tryNefJpegPreview(buffer);
+    const previewImageData = await decodeNefPreviewJpeg(stashedPreview);
     if (previewImageData) {
       console.warn('[RAW] embedded preview decoded — precision is downgraded to 8-bit for this file.');
       previewImageData.__image16 = fromImageData8(previewImageData);


### PR DESCRIPTION
A Nikon Z f high-efficiency NEF (17.9MB) failed to load with a "decode timed out" message — in under a second, so it was never actually a timeout. Console evidence showed the real chain:

1. `raw.open()` succeeds, metadata logs fine
2. `raw.imageData()` returns **empty** — libraw cannot decode the Zf/Z8/Z9 HE/HE* Bayer stream (the documented case)
3. The embedded-JPEG fallback — built for exactly this — **silently finds nothing**, even though the file carries a 6048×4032 preview that the same extractor locates in Node

## Root cause

libraw-wasm's `runFn` puts the input's ArrayBuffer in the postMessage **transfer list**, so `raw.open()` detaches the container buffer on the main thread (`byteLength` → 0). Every fallback that extracts from `buffer` after `open()` — the timeout path, the empty-result path, the Bayer-snow path — reads a zero-length buffer and bails at the `byteLength < 64` guard without logging anything. The fallback has been dead code since the transfer was introduced.

The same detach also broke **two-stage loading for >100MB files**: `_pendingFullResBuffer` stored the buffer the preview decode had just transferred away, so the background full-resolution decode could never work.

## Fix

- `rawFileLoader.js`: extract the preview and copy its bytes **before** handing the buffer to LibRaw; all post-open fallbacks decode from that stash. The pre-open heavy-IIQ shortcut keeps using the intact buffer.
- `nefJpegPreview.js`: split out `decodeNefPreviewJpeg()` so extraction (pure, Node-testable) and decoding (browser) separate cleanly; `tryNefJpegPreview` is unchanged in behavior.
- `main.js`: the heavy-file preview stage receives `arrayBuffer.slice(0)` so the original stays alive for the scheduled full-res decode.
- The shared fallback log line no longer claims "timed out" for decode failures.

## Verification

- New `nefJpegPreview.test.mjs`: extraction, thumbnail skipping (<1000px), and the detached-buffer failure mode reproduced via `ArrayBuffer.prototype.transfer()` — 20/20 test files pass
- Chrome (via MCP): the Zf NEF now loads via the embedded preview — console shows `imageData returned empty result` → `using embedded preview (8-bit precision)` — full Kodak GC400 strip renders at Step 1 and converts through Step 3 with no page errors
- `npm run build:web` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ci5TNGa5HH6LN78ERN1Qu