### PR TITLE
Suppress isolated sensor defects on RAW decode so dead photosites stop exporting as red dots

### DIFF
--- a/negative2positive/src/app/rawFileLoader.js
+++ b/negative2positive/src/app/rawFileLoader.js
@@ -7,6 +7,7 @@ import {
   toImageData8
 } from '../silvercore/util/image16.js';
 import { looksLikeBayerSnow } from '../silvercore/util/garbledCheck.js';
+import { suppressSensorDefectsInWorker } from './sensorDefectsClient.js';
 import { tryNefJpegPreview, extractNefPreviewJpeg, decodeNefPreviewJpeg } from './nefJpegPreview.js';
 
 const UTIF = (UTIFImport && typeof UTIFImport.decode === 'function')
@@ -295,6 +296,23 @@ export async function loadRawFile(buffer, fileName, options = {}) {
     const garbledErr = new Error('RAW decode produced garbled output and no usable embedded preview was found');
     garbledErr.code = 'RAW_DECODE_GARBLED';
     throw garbledErr;
+  }
+
+  // LibRaw does no hot/dead pixel mapping. A stuck photosite is harmless in a
+  // normal photo but turns into a saturated single-colour dot once the
+  // negative is inverted (dead red photosite → red dot in every shadow).
+  try {
+    const defects = options.suppressSensorDefects === false
+      ? { repaired: 0 }
+      : await suppressSensorDefectsInWorker(image16);
+    if (defects.repaired > 0) {
+      console.info(`[RAW] suppressed ${defects.repaired} isolated sensor defect(s) (R ${defects.perChannel[0]}, G ${defects.perChannel[1]}, B ${defects.perChannel[2]}; dead ${defects.dead}, hot ${defects.hot})`);
+    }
+  } catch (err) {
+    // Only reachable if the worker died after taking the pixels; recover the
+    // way a decode timeout does rather than failing the whole load.
+    console.warn('[RAW] sensor defect suppression lost the decode, falling back to embedded preview:', err?.message || err);
+    return await handleTimeoutFallback();
   }
 
   const imageData = toImageData8(image16);

--- a/negative2positive/src/app/sensorDefectsClient.js
+++ b/negative2positive/src/app/sensorDefectsClient.js
@@ -1,0 +1,119 @@
+/**
+ * Promise bridge to the sensor-defect suppression worker.
+ *
+ * The decoded RAW buffer is transferred (not copied) to the worker, so a
+ * worker that never comes up would swallow the pixels. We therefore ping the
+ * worker once before the first transfer and fall back to the main-thread
+ * implementation whenever the worker is unavailable; a crash mid-run is
+ * surfaced as a rejection so the loader can take its embedded-preview path.
+ */
+import { suppressSensorDefects } from '../silvercore/util/sensorDefects.js';
+
+const PING_TIMEOUT_MS = 5000;
+
+let worker = null;
+let workerReady = null; // Promise<boolean>
+let requestId = 0;
+const pending = new Map();
+
+function rejectAll(err) {
+  for (const [id, entry] of pending) {
+    pending.delete(id);
+    entry.reject(err);
+  }
+}
+
+function getWorker() {
+  if (worker) return worker;
+  worker = new Worker(
+    new URL('../workers/sensorDefectsWorker.js', import.meta.url),
+    { type: 'module' }
+  );
+  worker.onmessage = (e) => {
+    const msg = e.data;
+    const entry = pending.get(msg.id);
+    if (!entry) return;
+    pending.delete(msg.id);
+    if (msg.type === 'result' || msg.type === 'pong') entry.resolve(msg);
+    else entry.reject(new Error(msg.message || 'Sensor defect worker error'));
+  };
+  worker.onerror = (err) => {
+    console.error('Sensor defect worker crashed:', err);
+    rejectAll(new Error('Sensor defect worker crashed'));
+    try { worker.terminate(); } catch {}
+    worker = null;
+    workerReady = null;
+  };
+  return worker;
+}
+
+function request(message, transfer) {
+  const w = getWorker();
+  const id = ++requestId;
+  message.id = id;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    try {
+      w.postMessage(message, transfer || []);
+    } catch (err) {
+      pending.delete(id);
+      reject(err);
+    }
+  });
+}
+
+function ensureWorkerReady() {
+  if (workerReady) return workerReady;
+  workerReady = (async () => {
+    try {
+      let timer;
+      const timeout = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error('Sensor defect worker ping timed out')), PING_TIMEOUT_MS);
+      });
+      await Promise.race([request({ type: 'ping' }), timeout]);
+      clearTimeout(timer);
+      return true;
+    } catch (err) {
+      console.warn('[RAW] sensor defect worker unavailable, repairing on the main thread:', err?.message || err);
+      try { worker?.terminate?.(); } catch {}
+      worker = null;
+      return false;
+    }
+  })();
+  return workerReady;
+}
+
+/**
+ * Repair isolated sensor defects in `image16` (RGBA Uint16Array), preferring
+ * the worker. On success `image16.data` is replaced by the returned buffer.
+ * Rejects only if the buffer was lost to a worker crash after transfer.
+ *
+ * @returns {Promise<{ repaired: number, dead: number, hot: number, perChannel: number[] }>}
+ */
+export async function suppressSensorDefectsInWorker(image16) {
+  const data = image16?.data;
+  const wholeBuffer = data instanceof Uint16Array
+    && data.byteOffset === 0
+    && data.byteLength === data.buffer.byteLength;
+  if (typeof Worker === 'undefined' || !wholeBuffer) {
+    return suppressSensorDefects(image16);
+  }
+  if (!(await ensureWorkerReady())) {
+    return suppressSensorDefects(image16);
+  }
+
+  const { width, height } = image16;
+  const buffer = data.buffer;
+  let result;
+  try {
+    result = await request({ type: 'suppress', width, height, buffer }, [buffer]);
+  } catch (err) {
+    if (buffer.byteLength > 0) {
+      // postMessage refused the transfer — pixels are still ours.
+      return suppressSensorDefects(image16);
+    }
+    throw err;
+  }
+  image16.data = new Uint16Array(result.buffer);
+  return result.stats;
+}

--- a/negative2positive/src/silvercore/util/sensorDefects.js
+++ b/negative2positive/src/silvercore/util/sensorDefects.js
@@ -1,0 +1,164 @@
+// Suppresses isolated single-channel sensor defects in a demosaiced RAW decode.
+//
+// LibRaw hands us the sensor data as-is: it does no hot/dead pixel mapping
+// (the camera only does that for its own JPEGs). A photosite that is stuck
+// low is nearly invisible in a normal photo, but a film negative gets
+// inverted — on a colour negative the red channel sits near the top of the
+// range in the thin (shadow) areas, so a dead red photosite becomes a
+// saturated red dot on black after inversion. Dead green/blue photosites
+// turn into green/blue dots, hot ones into single-channel dark dots in the
+// highlights. Demosaicing also smears the defect into the 3×3 neighbourhood
+// (colour-difference interpolation pulls the adjacent pixels ~25–50 % of the
+// way), which is why the dots look 2–3 px wide in an export.
+//
+// Detection: per channel, a pixel is a defect when it lies outside the
+// min/max of its 5×5 ring (the 16 pixels at Chebyshev distance 2 — distance
+// 1 is already contaminated) by a margin scaled from the ring's own spread:
+// ×2.5 the near-side spread (min→median for a dead candidate, median→max
+// for a hot one — ~1.7σ for 16 samples, so the margin sits ~6σ past the
+// extreme and plain noise never qualifies) and at least ×1 the full spread
+// (so a lower half that happens to cluster cannot make a 4σ wiggle look
+// isolated, while a ring straddling an edge still catches a fully dead
+// photosite on its dark side). Real content — dust, grain, specular points, a
+// distant star — is neutral and moves all three channels together, so a
+// candidate whose other channels deviate by a comparable amount is left
+// alone. Only isolated points qualify: a line or an edge always has ring
+// pixels of its own kind and never trips the test.
+//
+// Rings near the black floor are left alone: they say nothing about noise
+// (an underexposed scan pushed by auto-bright has quantisation steps of
+// several thousand, and the near-black blue channel under an orange mask is
+// full of clipped zeros), and everything there inverts into a blown
+// highlight anyway. So a "hot" pixel on a black-floor ring must reach a
+// tenth of full scale, and a "dead" pixel is only chased where the ring's
+// lower median clears twice the absolute floor. A clipped-bright ring is
+// the opposite and the classic case (thin negative → deep positive shadow):
+// any pixel clearly below the clip is a defect.
+//
+// Repair: the centre takes the ring median in that channel; each of the 8
+// contaminated neighbours is rebuilt from the ring pixels adjacent to it,
+// but only when it actually deviates from that estimate in the defect's
+// direction (a half-size/binned decode has no smear and stays untouched).
+
+const PIXEL_MAX = 65535;
+const DEFAULT_ABSOLUTE_THRESHOLD = 1500;   // ~2.3 % of full scale — never chase sub-noise-floor wiggles
+const DEFAULT_NOISE_FACTOR = 2.5;          // × the ring's near-side spread (min→median or median→max)
+const FULL_SPREAD_FACTOR = 1;              // margin is never below the ring's whole min→max spread
+const BLACK_FLOOR_HOT_THRESHOLD = 0.1 * PIXEL_MAX; // hot margin when the ring sits on the black floor
+const BLACK_FLOOR_DEAD_LEVEL = 2 * DEFAULT_ABSOLUTE_THRESHOLD; // no dead candidates below this ring level
+const CORRELATED_FRACTION = 0.25;          // other channel moving ≥ this × the defect ⇒ real content
+
+const PATCH = [];   // 8 neighbours: { dx, dy, ring: [indices into RING] }
+const RING = [];    // 16 pixels at Chebyshev distance 2
+for (let dy = -2; dy <= 2; dy++) {
+  for (let dx = -2; dx <= 2; dx++) {
+    if (Math.max(Math.abs(dx), Math.abs(dy)) === 2) RING.push({ dx, dy });
+  }
+}
+for (let dy = -1; dy <= 1; dy++) {
+  for (let dx = -1; dx <= 1; dx++) {
+    if (dx === 0 && dy === 0) continue;
+    const ring = [];
+    RING.forEach((p, k) => {
+      if (Math.max(Math.abs(p.dx - dx), Math.abs(p.dy - dy)) <= 1) ring.push(k);
+    });
+    PATCH.push({ dx, dy, ring });
+  }
+}
+
+/**
+ * @param {{ width: number, height: number, data: Uint16Array }} image16 RGBA, modified in place
+ * @param {{ absoluteThreshold?: number, noiseFactor?: number }} [options]
+ * @returns {{ repaired: number, dead: number, hot: number, perChannel: number[] }}
+ */
+export function suppressSensorDefects(image16, options = {}) {
+  const stats = { repaired: 0, dead: 0, hot: 0, perChannel: [0, 0, 0] };
+  if (!image16 || !(image16.data instanceof Uint16Array)) return stats;
+  const { width, height, data } = image16;
+  if (width < 5 || height < 5) return stats;
+
+  const abs = Number.isFinite(options.absoluteThreshold) ? options.absoluteThreshold : DEFAULT_ABSOLUTE_THRESHOLD;
+  const noise = Number.isFinite(options.noiseFactor) ? options.noiseFactor : DEFAULT_NOISE_FACTOR;
+  const stride = width * 4;
+  const ringOff = RING.map((p) => (p.dy * width + p.dx) * 4);
+  const patchOff = PATCH.map((p) => (p.dy * width + p.dx) * 4);
+  const ringValues = new Float64Array(16); // ring in RING order (for the neighbour estimates)
+  const sorted = new Float64Array(16);     // same values, ascending
+  const byValue = (a, b) => a - b;
+
+  // Fill ringValues/sorted for channel c around pixel i.
+  const readRing = (i, c) => {
+    for (let k = 0; k < 16; k++) ringValues[k] = data[i + ringOff[k] + c];
+    sorted.set(ringValues);
+    sorted.sort(byValue);
+  };
+
+  // How far past the ring extreme `v` sits, in the given direction (≤ 0 ⇒ inside the ring).
+  const excess = (v, dir) => (dir < 0 ? sorted[0] - v : v - sorted[15]);
+
+  // Margin a candidate must clear on that side.
+  const margin = (dir) => {
+    const fullSpread = FULL_SPREAD_FACTOR * (sorted[15] - sorted[0]);
+    if (dir < 0) return Math.max(abs, noise * (sorted[7] - sorted[0]), fullSpread);
+    const fromSpread = Math.max(noise * (sorted[15] - sorted[8]), fullSpread);
+    if (sorted[0] <= abs) return Math.max(BLACK_FLOOR_HOT_THRESHOLD, fromSpread);
+    return Math.max(abs, fromSpread);
+  };
+
+  for (let y = 2; y < height - 2; y++) {
+    let i = (y * width + 2) * 4;
+    for (let x = 2; x < width - 2; x++, i += 4) {
+      for (let c = 0; c < 3; c++) {
+        const v = data[i + c];
+        // Cheap reject against the 4 direct neighbours — almost every pixel exits here.
+        const l = data[i - 4 + c], r = data[i + 4 + c], u = data[i - stride + c], d = data[i + stride + c];
+        let mn = l < r ? l : r; if (u < mn) mn = u; if (d < mn) mn = d;
+        let mx = l > r ? l : r; if (u > mx) mx = u; if (d > mx) mx = d;
+        if (v + abs >= mn && v <= mx + abs) continue;
+
+        readRing(i, c);
+        const dir = v < sorted[0] ? -1 : v > sorted[15] ? 1 : 0;
+        if (dir === 0) continue;
+        if (dir < 0 && sorted[7] <= BLACK_FLOOR_DEAD_LEVEL) continue;
+        const deviation = excess(v, dir);
+        if (deviation <= margin(dir)) continue;
+
+        // Neutral features move every channel by a comparable amount: leave those alone.
+        let correlated = false;
+        for (let c2 = 0; c2 < 3 && !correlated; c2++) {
+          if (c2 === c) continue;
+          readRing(i, c2);
+          if (excess(data[i + c2], dir) >= CORRELATED_FRACTION * deviation) correlated = true;
+        }
+        if (correlated) continue;
+
+        // Repair centre from the (uncontaminated) ring.
+        readRing(i, c);
+        const median = (sorted[7] + sorted[8]) / 2;
+        const magnitude = Math.abs(v - median);
+        data[i + c] = Math.round(median);
+
+        // Repair the smeared neighbours where they actually deviate. Demosaic
+        // smear is ~1/2 of the defect on the 4-neighbours and ~1/4 on the
+        // diagonals, so anything past 1/8 (and above the noise floor) counts.
+        const smearThreshold = Math.max(0.5 * abs, magnitude / 8);
+        for (let j = 0; j < 8; j++) {
+          const p = PATCH[j];
+          let sum = 0;
+          for (let k = 0; k < p.ring.length; k++) sum += ringValues[p.ring[k]];
+          const estimate = sum / p.ring.length;
+          const ni = i + patchOff[j] + c;
+          const nv = data[ni];
+          if (dir < 0 ? nv < estimate - smearThreshold : nv > estimate + smearThreshold) {
+            data[ni] = Math.max(0, Math.min(PIXEL_MAX, Math.round(estimate)));
+          }
+        }
+
+        stats.repaired++;
+        stats.perChannel[c]++;
+        if (dir < 0) stats.dead++; else stats.hot++;
+      }
+    }
+  }
+  return stats;
+}

--- a/negative2positive/src/silvercore/util/sensorDefects.test.mjs
+++ b/negative2positive/src/silvercore/util/sensorDefects.test.mjs
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { suppressSensorDefects } from './sensorDefects.js';
+
+const W = 64;
+const H = 64;
+
+// Deterministic PRNG so the noise field is reproducible.
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1103515245 + 12345) >>> 0;
+    return (s & 0x7fffffff) / 0x7fffffff;
+  };
+}
+
+// Orange-mask-like negative: bright red, mid green, dark blue, gentle gradient, ±1.5 % grain.
+// `noiseAmplitude` is the peak-to-peak fraction, one number or one per channel.
+function makeNegative(seed = 7, noiseAmplitude = 0.03, base = [48000, 30000, 18000]) {
+  const rnd = makeRng(seed);
+  const amp = Array.isArray(noiseAmplitude) ? noiseAmplitude : [noiseAmplitude, noiseAmplitude, noiseAmplitude];
+  const data = new Uint16Array(W * H * 4);
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const i = (y * W + x) * 4;
+      const g = 1 + 0.1 * (x / W) - 0.05 * (y / H);
+      for (let c = 0; c < 3; c++) {
+        data[i + c] = Math.max(0, Math.min(65535, Math.round(base[c] * g * (1 + (rnd() - 0.5) * amp[c]))));
+      }
+      data[i + 3] = 65535;
+    }
+  }
+  return { width: W, height: H, data };
+}
+
+// Emulates what AHD demosaicing does to a stuck photosite: the centre takes the
+// stuck value, the 4-neighbours move half-way, the diagonals a quarter of the way.
+function smearDefect(img, x, y, c, stuckValue) {
+  const { width, data } = img;
+  const spread = [
+    [0, 0, 1], [1, 0, 0.5], [-1, 0, 0.5], [0, 1, 0.5], [0, -1, 0.5],
+    [1, 1, 0.25], [-1, 1, 0.25], [1, -1, 0.25], [-1, -1, 0.25],
+  ];
+  for (const [dx, dy, f] of spread) {
+    const i = ((y + dy) * width + (x + dx)) * 4 + c;
+    data[i] = Math.round(data[i] + (stuckValue - data[i]) * f);
+  }
+}
+
+function pixel(img, x, y, c) {
+  return img.data[(y * img.width + x) * 4 + c];
+}
+
+function assertPatchRestored(repaired, clean, x, y, c, tolerance = 0.06) {
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      const got = pixel(repaired, x + dx, y + dy, c);
+      const want = pixel(clean, x + dx, y + dy, c);
+      assert.ok(
+        Math.abs(got - want) <= want * tolerance,
+        `pixel (${x + dx},${y + dy}) ch${c}: got ${got}, clean ${want}`
+      );
+    }
+  }
+}
+
+function countChanged(a, b) {
+  let n = 0;
+  for (let i = 0; i < a.data.length; i++) if (a.data[i] !== b.data[i]) n++;
+  return n;
+}
+
+// --- clean image stays untouched ---
+{
+  const img = makeNegative();
+  const before = { ...img, data: new Uint16Array(img.data) };
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 0, 'clean image must not be touched');
+  assert.equal(countChanged(img, before), 0);
+}
+
+// --- dead red photosite (the exported-red-dots bug) is repaired, neighbours included ---
+{
+  const clean = makeNegative();
+  const img = { ...clean, data: new Uint16Array(clean.data) };
+  smearDefect(img, 20, 20, 0, 0);
+  assert.ok(pixel(img, 20, 20, 0) === 0);
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 1);
+  assert.equal(stats.dead, 1);
+  assert.deepEqual(stats.perChannel, [1, 0, 0]);
+  assertPatchRestored(img, clean, 20, 20, 0);
+  // Green/blue of the patch and everything outside the 3×3 stay bit-identical.
+  let outside = 0;
+  for (let i = 0; i < img.data.length; i++) {
+    if (img.data[i] === clean.data[i]) continue;
+    const px = (i >> 2) % W, py = Math.floor((i >> 2) / W), c = i & 3;
+    assert.equal(c, 0, `only the red channel may change (idx ${i})`);
+    if (Math.abs(px - 20) > 1 || Math.abs(py - 20) > 1) outside++;
+  }
+  assert.equal(outside, 0, 'no pixel outside the defect patch may change');
+}
+
+// --- dead green, dead blue and hot photosites are handled the same way ---
+{
+  const clean = makeNegative(3);
+  const img = { ...clean, data: new Uint16Array(clean.data) };
+  smearDefect(img, 10, 40, 1, 0);        // dead green
+  smearDefect(img, 40, 10, 2, 0);        // dead blue
+  smearDefect(img, 45, 45, 0, 65535);    // hot red
+  smearDefect(img, 30, 30, 1, 65535);    // hot green
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 4);
+  assert.equal(stats.dead, 2);
+  assert.equal(stats.hot, 2);
+  assertPatchRestored(img, clean, 10, 40, 1);
+  assertPatchRestored(img, clean, 40, 10, 2);
+  assertPatchRestored(img, clean, 45, 45, 0);
+  assertPatchRestored(img, clean, 30, 30, 1);
+}
+
+// --- a stuck pixel without demosaic smear (half-size decode) repairs only the centre ---
+{
+  const clean = makeNegative(5);
+  const img = { ...clean, data: new Uint16Array(clean.data) };
+  img.data[(25 * W + 25) * 4] = 0;
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 1);
+  assertPatchRestored(img, clean, 25, 25, 0);
+  assert.equal(countChanged(img, clean), 1, 'untouched neighbours must stay bit-identical');
+}
+
+// --- neutral content (moves all channels) is real image detail: leave it alone ---
+{
+  const clean = makeNegative(11);
+  const img = { ...clean, data: new Uint16Array(clean.data) };
+  // dust speck on the negative: every channel drops to ~15 % at the centre
+  for (let c = 0; c < 3; c++) smearDefect(img, 20, 20, c, Math.round(pixel(clean, 20, 20, c) * 0.15));
+  // emulsion pinhole / real specular point: every channel jumps to max
+  for (let c = 0; c < 3; c++) smearDefect(img, 44, 44, c, 65535);
+  const before = new Uint16Array(img.data);
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 0, 'neutral specks are content, not sensor defects');
+  assert.deepEqual(img.data, before);
+}
+
+// --- single-channel lines and edges are never isolated points ---
+{
+  const clean = makeNegative(13);
+  const img = { ...clean, data: new Uint16Array(clean.data) };
+  for (let x = 10; x < 30; x++) img.data[(33 * W + x) * 4] = Math.round(pixel(clean, x, 33, 0) * 0.3); // dark red line
+  for (let y = 0; y < H; y++) for (let x = 50; x < W; x++) img.data[(y * W + x) * 4 + 2] = 2000;    // blue step edge
+  const before = new Uint16Array(img.data);
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 0);
+  assert.deepEqual(img.data, before);
+}
+
+// --- heavy noise (underexposed scan pushed by auto-bright) is not a field of defects ---
+{
+  const clean = makeNegative(17, 0.5); // ±25 % per-pixel noise
+  const img = { ...clean, data: new Uint16Array(clean.data) };
+  const before = new Uint16Array(img.data);
+  assert.equal(suppressSensorDefects(img).repaired, 0, 'noise alone must never qualify');
+  assert.deepEqual(img.data, before);
+  // ...but a genuinely stuck photosite still stands out against that noise.
+  smearDefect(img, 32, 32, 0, 0);
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 1);
+  assert.deepEqual(stats.perChannel, [1, 0, 0]);
+}
+
+// --- near-black blue channel under an orange mask: black-level zeros are not dead pixels ---
+{
+  const img = makeNegative(19, [0.03, 0.03, 3.0], [48000, 30000, 1200]); // blue swings −0.5…2.5× → plenty of clamped zeros
+  let zeros = 0;
+  for (let i = 2; i < img.data.length; i += 4) if (img.data[i] === 0) zeros++;
+  assert.ok(zeros > 50, `fixture should contain black-level zeros (got ${zeros})`);
+  const before = new Uint16Array(img.data);
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 0, `black-floor noise flagged: ${JSON.stringify(stats)}`);
+  assert.deepEqual(img.data, before);
+}
+
+// --- crushed blacks: a lone quantisation step above a flat-zero ring is not a hot pixel ---
+{
+  const img = makeNegative(23, 0, [0, 0, 0]);
+  img.data[(30 * W + 30) * 4] = 3500;      // 1 LSB of a pushed decode
+  img.data[(10 * W + 40) * 4] = 20000;     // a real hot photosite
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 1);
+  assert.equal(pixel(img, 30, 30, 0), 3500, 'quantisation noise must survive');
+  assert.equal(pixel(img, 40, 10, 0), 0, 'strong hot pixel on black must be repaired');
+}
+
+// --- clipped highlights: a dead photosite inside a saturated red area is still repaired ---
+{
+  const img = makeNegative(29, 0, [65535, 30000, 18000]);
+  smearDefect(img, 20, 20, 0, 0);
+  const stats = suppressSensorDefects(img);
+  assert.equal(stats.repaired, 1);
+  assert.equal(pixel(img, 20, 20, 0), 65535);
+  assert.equal(pixel(img, 21, 20, 0), 65535);
+}
+
+// --- guards ---
+{
+  assert.deepEqual(suppressSensorDefects(null).repaired, 0);
+  assert.equal(suppressSensorDefects({ width: 3, height: 3, data: new Uint16Array(36) }).repaired, 0);
+  assert.equal(suppressSensorDefects({ width: 8, height: 8, data: new Uint8ClampedArray(256) }).repaired, 0);
+}
+
+console.log('sensorDefects tests passed');

--- a/negative2positive/src/workers/sensorDefectsWorker.js
+++ b/negative2positive/src/workers/sensorDefectsWorker.js
@@ -1,0 +1,27 @@
+/**
+ * Sensor-defect suppression worker — runs the isolated-outlier repair over a
+ * freshly decoded 16-bit RAW off the main thread. The pixel buffer is
+ * transferred in, repaired in place, and transferred back (zero-copy).
+ */
+import { suppressSensorDefects } from '../silvercore/util/sensorDefects.js';
+
+self.onmessage = function (e) {
+  const msg = e.data;
+  if (msg.type === 'ping') {
+    self.postMessage({ type: 'pong', id: msg.id });
+    return;
+  }
+  if (msg.type !== 'suppress') {
+    self.postMessage({ type: 'error', id: msg.id, message: `Unknown message type: ${msg.type}` });
+    return;
+  }
+  const { id, width, height, buffer } = msg;
+  try {
+    const data = new Uint16Array(buffer);
+    const stats = suppressSensorDefects({ width, height, data });
+    self.postMessage({ type: 'result', id, buffer, stats }, [buffer]);
+  } catch (err) {
+    // Hand the buffer back so the caller keeps its pixels even when we fail.
+    self.postMessage({ type: 'error', id, message: err?.message || String(err), buffer }, [buffer]);
+  }
+};


### PR DESCRIPTION
## Problem

A user reported scattered red dots in the dark areas of an exported conversion (`_DSC9306_converted.jpg`, Nikon RAW source). The dots only show in the shadows and are 2–3 px wide.

## Root cause

The conversion/export pipeline (SilverCore LUTs, film-base compensation, sharpening, 3D LUT, Step‑3 8‑bit adjustments, JPEG encode) is fully clamped and cannot create isolated single-colour pixels. The dots are **sensor defects in the RAW**: LibRaw does no hot/dead pixel mapping (cameras only apply it to their own JPEGs). On a colour negative the red channel sits at the top of the range in the thin areas, so a red photosite stuck low becomes a saturated red dot after inversion — exactly in the positive's shadows, and invisible in its highlights. Demosaicing smears it across 3×3. The preview hides them because it downsamples by skipping pixels; the full-resolution export keeps every one.

Injecting dead red photosites into a real NEF and running the real pipeline reproduces the reported look pixel-for-pixel (dark area: 253/11/19 on a 2/8/14 background; bright area: invisible).

## Fix

- `silvercore/util/sensorDefects.js`: per-channel isolated-outlier repair on the 16-bit LibRaw decode. A pixel is a defect when it lies past its 5×5 ring's min/max by a margin scaled from the ring's own spread **and** the other two channels do not move with it (dust, grain, specular points are neutral and stay). Centre → ring median; the smeared 3×3 neighbours are rebuilt from the ring. Black-floor rings are skipped (they invert to blown highlights; an auto-bright push turns single quantisation steps into spikes).
- `workers/sensorDefectsWorker.js` + `app/sensorDefectsClient.js`: runs off the main thread with zero-copy buffer transfer, pinging the worker before the first transfer and falling back to the main thread when unavailable.
- `app/rawFileLoader.js`: applied after the Bayer-snow check; logs `[RAW] suppressed N isolated sensor defect(s)`; `{ suppressSensorDefects: false }` disables it.

## Verification

- `npm test` 23/23 (new `sensorDefects.test.mjs` covers dead/hot in every channel, no-smear decodes, neutral specks, lines/edges, heavy noise, black-floor zeros, clipped highlights)
- `npm run test:smoke` PASS, `npm run build:web` OK (worker bundles)
- Real files through the app loader in headless Chrome:
  - `_DSC3111.NEF` (10.7 MP): 300/300 injected dead red photosites repaired (green 49/50, blue 39/50 — misses sit on strong edges or in the near-black blue channel and are invisible after inversion); the clean decode gets 56 incidental single-channel outliers touched, none visible in the positive.
  - `_DSC5290.dng` (underexposed, crushed blacks): no false positives on the black-floor channels.
  - ~0.5 s per 10.7 MP / ~1 s per 24 MP, in the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEix63EejESyZLCrD2mBq6
